### PR TITLE
Use a type-aligned SplitSeq to store the continuation frames

### DIFF
--- a/convention-plugins/src/main/kotlin/module.publication.gradle.kts
+++ b/convention-plugins/src/main/kotlin/module.publication.gradle.kts
@@ -18,26 +18,24 @@ publishing {
 
         // Provide artifacts information required by Maven Central
         pom {
-            name.set("Kotlin Multiplatform library template")
-            description.set("Dummy library to test deployment to Maven Central")
-            url.set("https://github.com/Kotlin/multiplatform-library-template")
+            name.set("KonTinuity")
+            description.set("Provides fully-fledged multishot delimitied continuations in Kotlin with Coroutines")
+            url.set("https://github.com/kyay10/kontinuity")
 
             licenses {
                 license {
-                    name.set("MIT")
-                    url.set("https://opensource.org/licenses/MIT")
+                    name.set("Apache-2.0")
+                    url.set("https://opensource.org/license/apache-2-0")
                 }
             }
             developers {
                 developer {
-                    id.set("JetBrains")
-                    name.set("JetBrains Team")
-                    organization.set("JetBrains")
-                    organizationUrl.set("https://www.jetbrains.com")
+                    id.set("kyay10")
+                    name.set("Youssef Shoaib")
                 }
             }
             scm {
-                url.set("https://github.com/Kotlin/multiplatform-library-template")
+                url.set("https://github.com/kyay10/kontinuity")
             }
         }
     }

--- a/convention-plugins/src/main/kotlin/root.publication.gradle.kts
+++ b/convention-plugins/src/main/kotlin/root.publication.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 allprojects {
-    group = "org.jetbrains.kotlinx.multiplatform-library-template"
+    group = "io.github.kyay10"
     version = "0.0.1"
 }
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
   alias(libs.plugins.kotlinMultiplatform)
@@ -18,6 +17,8 @@ kotlin {
     browser()
     nodejs {
       testTask {
+//        nodeJsArgs += "--prof-sampling-interval=10"
+//        nodeJsArgs += "--prof"
         useMocha {
           timeout = "600s"
         }
@@ -55,4 +56,13 @@ kotlin {
       dependsOn(nonJvmMain)
     }
   }
+}
+
+tasks.withType<Test> {
+  jvmArgs = listOf(
+    "-XX:+HeapDumpOnOutOfMemoryError",
+    "-Xmx600m",
+    // results in lots of thread name setting, which slows tests and throws off profiling, so we turn it off
+    "-Dkotlinx.coroutines.debug=off",
+  )
 }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 
 plugins {
@@ -12,7 +13,11 @@ kotlin {
   }
   explicitApi()
   applyDefaultHierarchyTemplate()
-  jvm()
+  jvm {
+    compilerOptions {
+      jvmTarget = JvmTarget.JVM_1_8
+    }
+  }
   js {
     browser()
     nodejs {
@@ -65,4 +70,14 @@ tasks.withType<Test> {
     // results in lots of thread name setting, which slows tests and throws off profiling, so we turn it off
     "-Dkotlinx.coroutines.debug=off",
   )
+}
+
+publishing {
+  publications.withType<MavenPublication> {
+    artifactId = if (name == "kotlinMultiplatform") {
+      "kontinuity"
+    } else {
+      "kontinuity-$name"
+    }
+  }
 }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -19,7 +19,7 @@ kotlin {
     nodejs {
       testTask {
         useMocha {
-          timeout = "120s"
+          timeout = "600s"
         }
       }
     }

--- a/library/karma.config.d/karma.conf.js
+++ b/library/karma.config.d/karma.conf.js
@@ -1,7 +1,7 @@
 config.set({
     client: {
         mocha: {
-            timeout: 120000
+            timeout: 600000
         }
     }
 })

--- a/library/karma.config.d/karma.conf.js
+++ b/library/karma.config.d/karma.conf.js
@@ -1,4 +1,10 @@
 config.set({
+    browserDisconnectTimeout: 600000,
+    browserNoActivityTimeout: 600000,
+    processKillTimeout: 600000,
+    captureTimeout: 600000,
+    browserDisconnectTolerance : 3,
+    pingTimeout: 600000,
     client: {
         mocha: {
             timeout: 600000

--- a/library/src/commonMain/kotlin/cloning.kt
+++ b/library/src/commonMain/kotlin/cloning.kt
@@ -1,17 +1,12 @@
+import arrow.core.tail
 import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.intrinsics.intercepted
 import kotlin.jvm.JvmInline
 
 internal expect val Continuation<*>.isCompilerGenerated: Boolean
 internal expect val Continuation<*>.completion: Continuation<*>
 internal expect fun <T> Continuation<T>.copy(completion: Continuation<*>): Continuation<T>
-
-internal fun <T, R> Continuation<T>.collectSubchain(hole: Continuation<R>): Subchain<T, R> =
-  Subchain(mutableListOf<Continuation<*>>().apply {
-    this@collectSubchain.forEach {
-      if (it == hole) return@apply
-      add(it)
-    }
-  })
 
 internal inline fun Continuation<*>.forEach(block: (Continuation<*>) -> Unit) {
   var current: Continuation<*> = this
@@ -19,35 +14,242 @@ internal inline fun Continuation<*>.forEach(block: (Continuation<*>) -> Unit) {
     block(current)
     current = when (current) {
       in CompilerGenerated -> current.completion
-      is CopyableContinuation -> current.completion
       else -> error("Continuation $current is not see-through, so its stack can't be traversed")
     }
   }
-}
-
-// list is a list of continuations from the current continuation to the hole
-// The last element is the hole itself, the first element is the current continuation
-@Suppress("UNCHECKED_CAST")
-@JvmInline
-internal value class Subchain<T, R>(private val list: MutableList<Continuation<*>>) {
-  fun replace(replacement: Continuation<R>): Continuation<T> {
-    var result: Continuation<*> = replacement
-    for (i in list.lastIndex downTo 0) result = when (val cont = list[i]) {
-      in CompilerGenerated -> cont.copy(result)
-      is CopyableContinuation -> cont.copy(result)
-      else -> error("Continuation $this is not cloneable")
-    }
-    return result as Continuation<T>
-  }
-
-  fun clear() = list.clear()
 }
 
 internal object CompilerGenerated {
   operator fun contains(cont: Continuation<*>): Boolean = cont.isCompilerGenerated
 }
 
-internal interface CopyableContinuation<T> : Continuation<T> {
-  val completion: Continuation<*>
-  fun copy(completion: Continuation<*>): CopyableContinuation<T>
+@JvmInline
+internal value class Frame<in A, out B>(val cont: Continuation<A>) {
+  fun resumeWith(value: Result<A>, into: Continuation<B>) = cont.copy(into).intercepted().resumeWith(value)
+}
+
+@JvmInline
+internal value class FrameList<in Start, First, out End>(val list: List<Continuation<*>>) {
+  fun isEmpty() = list.isEmpty()
+  fun head() = Frame<_, Any?>(list.first()) as Frame<Start, First>
+  fun tail() = FrameList<First, Nothing, End>(list.tail()) as FrameList<First, *, End>
+}
+
+internal sealed interface SplitSeq<in Start, out End> : Continuation<Start> {
+  val isEmpty: Boolean
+  val head: Frame<Start, *>
+  val tail: SplitSeq<*, End>
+
+  override fun resumeWith(result: Result<Start>) = if (nonEmpty) {
+    val exception = result.exceptionOrNull()
+    if (exception is SeekingStackException) exception.use(this)
+    else {
+      (head as Frame<Start, Any?>).resumeWith(result, tail as SplitSeq<Any?, End>)
+    }
+  } else error("No continuation to resume with $result")
+}
+
+internal tailrec fun <Start, End, P, FurtherStart> SplitSeq<Start, End>.splitAtAux(
+  p: Prompt<P>, seg: Segment<FurtherStart, Start>
+): Pair<Segment<FurtherStart, P>, SplitSeq<P, End>> = when (this) {
+  is EmptyCont -> error("Prompt not found $p in $seg")
+  is FramesCont<Start, *, *, End> -> rest.splitAtAux(p, FramesSegment(frame, frames, seg))
+  is PromptCont -> if (p === this.p) {
+    // Start and P are now unified, but the compiler doesn't get it
+    val pair: Pair<Segment<FurtherStart, Start>, SplitSeq<Start, End>> = seg to rest
+    pair as Pair<Segment<FurtherStart, P>, SplitSeq<P, End>>
+  } else {
+    rest.splitAtAux(p, PromptSegment(this.p, seg))
+  }
+
+  is ReaderCont<*, Start, End> -> rest.splitAtAux(
+    p, ReaderSegment(this.p as Reader<Any?>, state, fork as (Any?.() -> Any?), seg)
+  )
+}
+
+internal tailrec fun <Start, End, FurtherStart> SplitSeq<Start, End>.splitAtAux(
+  p: Reader<*>, seg: Segment<FurtherStart, Start>
+): Pair<Segment<FurtherStart, *>, SplitSeq<*, End>> = when (this) {
+  is EmptyCont -> error("Prompt not found $p in $seg")
+  is FramesCont<Start, *, *, End> -> rest.splitAtAux(p, FramesSegment(frame, frames, seg))
+  is PromptCont -> rest.splitAtAux(p, PromptSegment(this.p, seg))
+  is ReaderCont<*, Start, End> -> if (p === this.p) {
+    seg to rest
+  } else rest.splitAtAux(
+    p, ReaderSegment(this.p as Reader<Any?>, state, fork as (Any?.() -> Any?), seg)
+  )
+}
+
+internal tailrec fun <Start, End, P> SplitSeq<Start, End>.find(p: Prompt<P>): SplitSeq<P, End> = when (this) {
+  is EmptyCont -> error("Prompt not found $p")
+
+  is FramesCont<Start, *, *, End> -> rest.find(p)
+  is PromptCont -> if (p === this.p) rest as SplitSeq<P, End> else rest.find(p)
+  is ReaderCont<*, Start, End> -> rest.find(p)
+}
+
+internal tailrec fun <Start, End, S> SplitSeq<Start, End>.find(p: Reader<S>): S = when (this) {
+  is EmptyCont -> error("Reader not found $p")
+  is FramesCont<Start, *, *, End> -> rest.find(p)
+  is PromptCont -> rest.find(p)
+  is ReaderCont<*, Start, End> -> if (p === this.p) state as S else rest.find(p)
+}
+
+internal tailrec fun <Start, End, S> SplitSeq<Start, End>.findOrNull(p: Reader<S>): S? = when (this) {
+  is EmptyCont -> null
+  is FramesCont<Start, *, *, End> -> rest.findOrNull(p)
+  is PromptCont -> rest.findOrNull(p)
+  is ReaderCont<*, Start, End> -> if (p === this.p) state as S else rest.findOrNull(p)
+}
+
+internal val SplitSeq<*, *>.nonEmpty get() = !isEmpty
+
+internal fun <Start, End, P> SplitSeq<Start, End>.splitAt(p: Prompt<P>): Pair<Segment<Start, P>, SplitSeq<P, End>> =
+  splitAtAux(p, emptySegment())
+
+internal fun <Start, End> SplitSeq<Start, End>.splitAt(p: Reader<*>): Pair<Segment<Start, *>, SplitSeq<*, End>> =
+  splitAtAux(p, emptySegment())
+
+internal fun <P, End> SplitSeq<P, End>.pushPrompt(p: Prompt<P>): PromptCont<P, End> = PromptCont(p, this)
+internal fun <S, P, End> SplitSeq<P, End>.pushReader(p: Reader<S>, value: S, fork: S.() -> S): ReaderCont<S, P, End> =
+  ReaderCont(p, value, fork, this)
+
+internal data class EmptyCont<Start>(val underlying: Continuation<Start>) : SplitSeq<Start, Nothing> {
+  override val isEmpty = true
+  override val head get() = error("No head on EmptyCont")
+  override val tail get() = error("No tail on EmptyCont")
+
+  override val context: CoroutineContext
+    get() = underlying.context
+
+  override fun resumeWith(result: Result<Start>) = underlying.resumeWith(result)
+}
+
+internal fun <Start, First, End, FurtherEnd> FrameList<Start, First, End>.asFramesCont(rest: SplitSeq<End, FurtherEnd>): FramesCont<Start, First, End, FurtherEnd> =
+  FramesCont(head(), tail(), rest)
+
+// frame :: frames ::: rest
+internal data class FramesCont<Start, First, Last, End>(
+  val frame: Frame<Start, First>, val frames: FrameList<First, *, Last>, val rest: SplitSeq<Last, End>
+) : SplitSeq<Start, End> {
+  override val isEmpty get() = false
+  override val head: Frame<Start, *> get() = frame
+  override val tail: SplitSeq<*, End>
+    get() = if (frames.isEmpty()) rest
+    else frames.asFramesCont(rest)
+
+  //override fun <FurtherStart> push(f: Frame<FurtherStart, Start>) = FramesCont(f, frame prependTo frames, rest)
+
+  override val context: CoroutineContext = rest.context
+}
+
+internal data class PromptCont<Start, End>(
+  val p: Prompt<Start>, val rest: SplitSeq<Start, End>
+) : SplitSeq<Start, End> by rest {
+  override fun resumeWith(result: Result<Start>) {
+    val exception = result.exceptionOrNull()
+    if (exception is SeekingStackException) exception.use(this)
+    else rest.resumeWith(result)
+  }
+}
+
+internal data class ReaderCont<State, Start, End>(
+  val p: Reader<State>, val state: State, val fork: State.() -> State, val rest: SplitSeq<Start, End>
+) : SplitSeq<Start, End> by rest {
+  override fun resumeWith(result: Result<Start>) {
+    val exception = result.exceptionOrNull()
+    if (exception is SeekingStackException) exception.use(this)
+    else rest.resumeWith(result)
+  }
+}
+
+// sub continuations / stack segments
+// mirrors the stack, and so is in reverse order. allows easy access to the state
+// stored in the current prompt
+internal sealed interface Segment<in Start, out End>
+
+internal infix fun <Start, End, FurtherEnd> Segment<Start, End>.prependTo(stack: SplitSeq<End, FurtherEnd>): SplitSeq<Start, FurtherEnd> =
+  prependTo2(stack) as SplitSeq<Start, FurtherEnd>
+
+private tailrec infix fun <Start, End, FurtherEnd> Segment<Start, End>.prependTo2(stack: SplitSeq<End, FurtherEnd>): SplitSeq<*, *> =
+  when (this) {
+    is EmptySegment -> stack
+    is FramesSegment<Start, *, *, End> -> init.prependTo2(
+      FramesCont(
+        frame as Frame<Any?, Any?>, frames as FrameList<Any?, Any?, Any?>, stack as SplitSeq<Any?, *>
+      )
+    )
+
+    is PromptSegment<Start, End> -> init.prependTo2(PromptCont(prompt, stack))
+    is ReaderSegment<*, Start, End> -> {
+      val f = fork as (Any?.() -> Any?)
+      init.prependTo2(ReaderCont(prompt as Reader<Any?>, f(state), f, stack))
+    }
+  }
+
+internal fun <T> emptySegment(): Segment<T, T> = EmptySegment as Segment<T, T>
+
+internal data object EmptySegment : Segment<Any?, Any?>
+
+internal data class FramesSegment<FurtherStart, Start, First, End>(
+  val frame: Frame<Start, First>, val frames: FrameList<First, *, End>, val init: Segment<FurtherStart, Start>
+) : Segment<FurtherStart, End>
+
+internal data class PromptSegment<Start, End>(
+  val prompt: Prompt<End>, val init: Segment<Start, End>
+) : Segment<Start, End>
+
+internal data class ReaderSegment<State, Start, End>(
+  val prompt: Reader<State>, val state: State, val fork: (State.() -> State), val init: Segment<Start, End>
+) : Segment<Start, End>
+
+internal fun <R> collectStack(continuation: Continuation<R>): SplitSeq<R, *> {
+  val list = mutableListOf<Continuation<*>>()
+  val last: SplitSeq<*, *> = run {
+    continuation.forEach {
+      if (it is SplitSeq<*, *>) {
+        return@run it
+      }
+      // instead of copying every continuation, we could also just copy the last one
+      list.add(it.copy(EmptyContinuation(it.context)))
+    }
+    error("No SplitSeq found in stack")
+  }
+  return FrameList<R, Any?, Any?>(list).asFramesCont(last as SplitSeq<Any?, *>)
+}
+
+internal fun findNearestSplitSeq(continuation: Continuation<*>): SplitSeq<*, *> {
+  continuation.forEach {
+    if (it is SplitSeq<*, *>) {
+      return it
+    }
+  }
+  error("No SplitSeq found in stack")
+}
+
+private fun <R> collectStack2(continuation: Continuation<R>): SplitSeq<R, *> {
+  val list = mutableListOf<Continuation<*>>()
+  val last: SplitSeq<*, *> = run {
+    continuation.forEach {
+      if (it is SplitSeq<*, *>) {
+        return@run it
+      }
+      list.add(it.copy(EmptyContinuation(it.context)))
+    }
+    error("No SplitSeq found in stack")
+  }
+  return when {
+    list.isEmpty() -> last as SplitSeq<R, *>
+    last is FramesCont<*, *, *, *> -> {
+      list.add(last.frame.cont)
+      list.addAll(last.frames.list)
+      FrameList<R, Any?, Any?>(list).asFramesCont(last.rest as SplitSeq<Any?, *>)
+    }
+
+    else -> FrameList<R, Any?, Any?>(list).asFramesCont(last as SplitSeq<Any?, *>)
+  }
+}
+
+private data class EmptyContinuation(override val context: CoroutineContext) : Continuation<Any?> {
+  override fun resumeWith(result: Result<Any?>) = error("No continuation to resume with $result")
 }

--- a/library/src/commonMain/kotlin/cloning.kt
+++ b/library/src/commonMain/kotlin/cloning.kt
@@ -31,90 +31,90 @@ internal value class Frame<in A, out B>(val cont: Continuation<A>) {
 @JvmInline
 internal value class FrameList<in Start, First, out End>(val list: List<Continuation<*>>) {
   fun isEmpty() = list.isEmpty()
-  fun head() = Frame<_, Any?>(list.first()) as Frame<Start, First>
+  fun head() = Frame<_, First>(list.first() as Continuation<Start>)
   fun tail() = FrameList<First, Nothing, End>(list.tail()) as FrameList<First, *, End>
 }
 
-internal sealed interface SplitSeq<in Start, out End> : Continuation<Start> {
+internal sealed interface SplitSeq<in Start, First, out End> : Continuation<Start> {
   val isEmpty: Boolean
-  val head: Frame<Start, *>
-  val tail: SplitSeq<*, End>
+  val head: Frame<Start, First>
+  val tail: SplitSeq<First, *, End>
 
   override fun resumeWith(result: Result<Start>) = if (nonEmpty) {
     val exception = result.exceptionOrNull()
     if (exception is SeekingStackException) exception.use(this)
     else {
-      (head as Frame<Start, Any?>).resumeWith(result, tail as SplitSeq<Any?, End>)
+      head.resumeWith(result, tail)
     }
   } else error("No continuation to resume with $result")
 }
 
-internal tailrec fun <Start, End, P, FurtherStart> SplitSeq<Start, End>.splitAtAux(
-  p: Prompt<P>, seg: Segment<FurtherStart, Start>
-): Pair<Segment<FurtherStart, P>, SplitSeq<P, End>> = when (this) {
+internal tailrec fun <Start, First, End, P, FurtherStart, FurtherFirst> SplitSeq<Start, First, End>.splitAtAux(
+  p: Prompt<P>, seg: Segment<FurtherStart, FurtherFirst, Start>
+): Pair<Segment<FurtherStart, FurtherFirst, P>, SplitSeq<P, *, End>> = when (this) {
   is EmptyCont -> error("Prompt not found $p in $seg")
-  is FramesCont<Start, *, *, End> -> rest.splitAtAux(p, FramesSegment(frames, seg))
+  is FramesCont<Start, First, *, End> -> rest.splitAtAux(p, FramesSegment(frames, seg))
   is PromptCont -> if (p === this.p) {
     // Start and P are now unified, but the compiler doesn't get it
-    val pair: Pair<Segment<FurtherStart, Start>, SplitSeq<Start, End>> = seg to rest
-    pair as Pair<Segment<FurtherStart, P>, SplitSeq<P, End>>
+    val pair: Pair<Segment<FurtherStart, FurtherFirst, Start>, SplitSeq<Start, *, End>> = seg to rest
+    pair as Pair<Segment<FurtherStart, FurtherFirst, P>, SplitSeq<P, *, End>>
   } else {
     rest.splitAtAux(p, PromptSegment(this.p, seg))
   }
 
-  is ReaderCont<*, Start, End> -> rest.splitAtAux(
+  is ReaderCont<*, Start, First, End> -> rest.splitAtAux(
     p, ReaderSegment(this.p as Reader<Any?>, state, fork as (Any?.() -> Any?), seg)
   )
 }
 
-internal tailrec fun <Start, End, FurtherStart> SplitSeq<Start, End>.splitAtAux(
-  p: Reader<*>, seg: Segment<FurtherStart, Start>
-): Pair<Segment<FurtherStart, *>, SplitSeq<*, End>> = when (this) {
+internal tailrec fun <Start, First, End, FurtherStart, FurtherFirst> SplitSeq<Start, First, End>.splitAtAux(
+  p: Reader<*>, seg: Segment<FurtherStart, FurtherFirst, Start>
+): Pair<Segment<FurtherStart, FurtherFirst, *>, SplitSeq<*, *, End>> = when (this) {
   is EmptyCont -> error("Prompt not found $p in $seg")
-  is FramesCont<Start, *, *, End> -> rest.splitAtAux(p, FramesSegment(frames, seg))
+  is FramesCont<Start, First, *, End> -> rest.splitAtAux(p, FramesSegment(frames, seg))
   is PromptCont -> rest.splitAtAux(p, PromptSegment(this.p, seg))
-  is ReaderCont<*, Start, End> -> if (p === this.p) {
+  is ReaderCont<*, Start, First, End> -> if (p === this.p) {
     seg to rest
   } else rest.splitAtAux(
     p, ReaderSegment(this.p as Reader<Any?>, state, fork as (Any?.() -> Any?), seg)
   )
 }
 
-internal tailrec fun <Start, End, P> SplitSeq<Start, End>.find(p: Prompt<P>): SplitSeq<P, End> = when (this) {
+internal tailrec fun <Start, End, P> SplitSeq<Start, *, End>.find(p: Prompt<P>): SplitSeq<P, *, End> = when (this) {
   is EmptyCont -> error("Prompt not found $p")
 
   is FramesCont<Start, *, *, End> -> rest.find(p)
-  is PromptCont -> if (p === this.p) rest as SplitSeq<P, End> else rest.find(p)
-  is ReaderCont<*, Start, End> -> rest.find(p)
+  is PromptCont -> if (p === this.p) rest as SplitSeq<P, *, End> else rest.find(p)
+  is ReaderCont<*, Start, *, End> -> rest.find(p)
 }
 
-internal tailrec fun <Start, End, S> SplitSeq<Start, End>.find(p: Reader<S>): S = when (this) {
+internal tailrec fun <Start, End, S> SplitSeq<Start, *, End>.find(p: Reader<S>): S = when (this) {
   is EmptyCont -> error("Reader not found $p")
   is FramesCont<Start, *, *, End> -> rest.find(p)
   is PromptCont -> rest.find(p)
-  is ReaderCont<*, Start, End> -> if (p === this.p) state as S else rest.find(p)
+  is ReaderCont<*, Start, *, End> -> if (p === this.p) state as S else rest.find(p)
 }
 
-internal tailrec fun <Start, End, S> SplitSeq<Start, End>.findOrNull(p: Reader<S>): S? = when (this) {
+internal tailrec fun <Start, End, S> SplitSeq<Start, *, End>.findOrNull(p: Reader<S>): S? = when (this) {
   is EmptyCont -> null
   is FramesCont<Start, *, *, End> -> rest.findOrNull(p)
   is PromptCont -> rest.findOrNull(p)
-  is ReaderCont<*, Start, End> -> if (p === this.p) state as S else rest.findOrNull(p)
+  is ReaderCont<*, Start, *, End> -> if (p === this.p) state as S else rest.findOrNull(p)
 }
 
-internal val SplitSeq<*, *>.nonEmpty get() = !isEmpty
+internal val SplitSeq<*, *, *>.nonEmpty get() = !isEmpty
 
-internal fun <Start, End, P> SplitSeq<Start, End>.splitAt(p: Prompt<P>): Pair<Segment<Start, P>, SplitSeq<P, End>> =
+internal fun <Start, First, End, P> SplitSeq<Start, First, End>.splitAt(p: Prompt<P>): Pair<Segment<Start, First, P>, SplitSeq<P, *, End>> =
   splitAtAux(p, emptySegment())
 
-internal fun <Start, End> SplitSeq<Start, End>.splitAt(p: Reader<*>): Pair<Segment<Start, *>, SplitSeq<*, End>> =
+internal fun <Start, First, End> SplitSeq<Start, First, End>.splitAt(p: Reader<*>): Pair<Segment<Start, First, *>, SplitSeq<*, *, End>> =
   splitAtAux(p, emptySegment())
 
-internal fun <P, End> SplitSeq<P, End>.pushPrompt(p: Prompt<P>): PromptCont<P, End> = PromptCont(p, this)
-internal fun <S, P, End> SplitSeq<P, End>.pushReader(p: Reader<S>, value: S, fork: S.() -> S): ReaderCont<S, P, End> =
+internal fun <P, First, End> SplitSeq<P, First, End>.pushPrompt(p: Prompt<P>): PromptCont<P, First, End> = PromptCont(p, this)
+internal fun <S, P, First, End> SplitSeq<P, First, End>.pushReader(p: Reader<S>, value: S, fork: S.() -> S): ReaderCont<S, P, First, End> =
   ReaderCont(p, value, fork, this)
 
-internal data class EmptyCont<Start>(val underlying: Continuation<Start>) : SplitSeq<Start, Nothing> {
+internal data class EmptyCont<Start>(val underlying: Continuation<Start>) : SplitSeq<Start, Nothing, Nothing> {
   override val isEmpty = true
   override val head get() = error("No head on EmptyCont")
   override val tail get() = error("No tail on EmptyCont")
@@ -125,26 +125,30 @@ internal data class EmptyCont<Start>(val underlying: Continuation<Start>) : Spli
   override fun resumeWith(result: Result<Start>) = underlying.resumeWith(result)
 }
 
-internal fun <Start, First, End, FurtherEnd> FrameList<Start, First, End>.asFramesCont(rest: SplitSeq<End, FurtherEnd>): SplitSeq<Start, FurtherEnd> =
-  if(isEmpty()) rest as SplitSeq<Start, FurtherEnd> else FramesCont(this, rest)
+internal fun <Start, First, End, FurtherEnd> FrameList<Start, First, End>.asFramesCont(rest: SplitSeq<End, *, FurtherEnd>): SplitSeq<Start, First, FurtherEnd> =
+  if(isEmpty()) rest as SplitSeq<Start, First, FurtherEnd> else FramesCont(this, rest)
 
 // frame :: frames ::: rest
 internal data class FramesCont<Start, First, Last, End>(
-  val frames: FrameList<Start, First, Last>, val rest: SplitSeq<Last, End>
-) : SplitSeq<Start, End> {
+  val frames: FrameList<Start, First, Last>, val rest: SplitSeq<Last, *, End>
+) : SplitSeq<Start, First, End> {
   override val isEmpty get() = false
-  override val head: Frame<Start, *> get() = frames.head()
-  override val tail: SplitSeq<*, End>
-    get() = frames.tail().asFramesCont(rest)
+  override val head get() = frames.head()
+  override val tail get() = frames.tail().asFramesCont(rest)
 
   //override fun <FurtherStart> push(f: Frame<FurtherStart, Start>) = FramesCont(f, frame prependTo frames, rest)
 
   override val context: CoroutineContext = rest.context
 }
 
-internal data class PromptCont<Start, End>(
-  val p: Prompt<Start>, val rest: SplitSeq<Start, End>
-) : SplitSeq<Start, End> by rest {
+internal data class PromptCont<Start, First, End>(
+  val p: Prompt<Start>, val rest: SplitSeq<Start, First, End>
+) : SplitSeq<Start, First, End> {
+  override val isEmpty get() = rest.isEmpty
+  override val head get() = rest.head
+  override val tail get() = rest.tail
+  override val context get() = rest.context
+
   override fun resumeWith(result: Result<Start>) {
     val exception = result.exceptionOrNull()
     if (exception is SeekingStackException) exception.use(this)
@@ -152,9 +156,14 @@ internal data class PromptCont<Start, End>(
   }
 }
 
-internal data class ReaderCont<State, Start, End>(
-  val p: Reader<State>, val state: State, val fork: State.() -> State, val rest: SplitSeq<Start, End>
-) : SplitSeq<Start, End> by rest {
+internal data class ReaderCont<State, Start, First, End>(
+  val p: Reader<State>, val state: State, val fork: State.() -> State, val rest: SplitSeq<Start, First, End>
+) : SplitSeq<Start, First, End> {
+  override val isEmpty get() = rest.isEmpty
+  override val head get() = rest.head
+  override val tail get() = rest.tail
+  override val context get() = rest.context
+
   override fun resumeWith(result: Result<Start>) {
     val exception = result.exceptionOrNull()
     if (exception is SeekingStackException) exception.use(this)
@@ -165,48 +174,48 @@ internal data class ReaderCont<State, Start, End>(
 // sub continuations / stack segments
 // mirrors the stack, and so is in reverse order. allows easy access to the state
 // stored in the current prompt
-internal sealed interface Segment<in Start, out End>
+internal sealed interface Segment<in Start, First, out End>
 
-internal infix fun <Start, End, FurtherEnd> Segment<Start, End>.prependTo(stack: SplitSeq<End, FurtherEnd>): SplitSeq<Start, FurtherEnd> =
-  prependTo2(stack) as SplitSeq<Start, FurtherEnd>
+internal infix fun <Start, First, End, FurtherEnd> Segment<Start, First, End>.prependTo(stack: SplitSeq<End, *, FurtherEnd>): SplitSeq<Start, First, FurtherEnd> =
+  prependTo2(stack) as SplitSeq<Start, First, FurtherEnd>
 
-private tailrec infix fun <Start, End, FurtherEnd> Segment<Start, End>.prependTo2(stack: SplitSeq<End, FurtherEnd>): SplitSeq<*, *> =
+private tailrec infix fun <Start, First, End, FurtherEnd> Segment<Start, First, End>.prependTo2(stack: SplitSeq<End, *, FurtherEnd>): SplitSeq<*, *, *> =
   when (this) {
     is EmptySegment -> stack
-    is FramesSegment<Start, *, *, End> -> init.prependTo2(
+    is FramesSegment<Start, First, *, *, End> -> init.prependTo2(
       FramesCont(
-        frames as FrameList<Any?, Any?, Any?>, stack as SplitSeq<Any?, *>
+        frames as FrameList<Any?, Any?, Any?>, stack as SplitSeq<Any?, *, *>
       )
     )
 
-    is PromptSegment<Start, End> -> init.prependTo2(PromptCont(prompt, stack))
-    is ReaderSegment<*, Start, End> -> {
+    is PromptSegment<Start, First, End> -> init.prependTo2(PromptCont(prompt, stack))
+    is ReaderSegment<*, Start, First, End> -> {
       val f = fork as (Any?.() -> Any?)
       init.prependTo2(ReaderCont(prompt as Reader<Any?>, f(state), f, stack))
     }
   }
 
-internal fun <T> emptySegment(): Segment<T, T> = EmptySegment as Segment<T, T>
+internal fun <T, First> emptySegment(): Segment<T, First, T> = EmptySegment as Segment<T, First, T>
 
-internal data object EmptySegment : Segment<Any?, Any?>
+internal data object EmptySegment : Segment<Any?, Nothing, Any?>
 
-internal data class FramesSegment<FurtherStart, Start, First, End>(
-  val frames: FrameList<Start, First, End>, val init: Segment<FurtherStart, Start>
-) : Segment<FurtherStart, End>
+internal data class FramesSegment<FurtherStart, FurtherFirst, Start, First, End>(
+  val frames: FrameList<Start, First, End>, val init: Segment<FurtherStart, FurtherFirst, Start>
+) : Segment<FurtherStart, FurtherFirst, End>
 
-internal data class PromptSegment<Start, End>(
-  val prompt: Prompt<End>, val init: Segment<Start, End>
-) : Segment<Start, End>
+internal data class PromptSegment<Start, First, End>(
+  val prompt: Prompt<End>, val init: Segment<Start, First, End>
+) : Segment<Start, First, End>
 
-internal data class ReaderSegment<State, Start, End>(
-  val prompt: Reader<State>, val state: State, val fork: (State.() -> State), val init: Segment<Start, End>
-) : Segment<Start, End>
+internal data class ReaderSegment<State, Start, First, End>(
+  val prompt: Reader<State>, val state: State, val fork: (State.() -> State), val init: Segment<Start, First, End>
+) : Segment<Start, First, End>
 
-internal fun <R> collectStack(continuation: Continuation<R>): SplitSeq<R, *> {
+internal fun <R> collectStack(continuation: Continuation<R>): SplitSeq<R, *, *> {
   val list = mutableListOf<Continuation<*>>()
-  val last: SplitSeq<*, *> = run {
+  val last: SplitSeq<*, *, *> = run {
     continuation.forEach {
-      if (it is SplitSeq<*, *>) {
+      if (it is SplitSeq<*, *, *>) {
         return@run it
       }
       // instead of copying every continuation, we could also just copy the last one
@@ -214,23 +223,23 @@ internal fun <R> collectStack(continuation: Continuation<R>): SplitSeq<R, *> {
     }
     error("No SplitSeq found in stack")
   }
-  return FrameList<R, Any?, Any?>(list).asFramesCont(last as SplitSeq<Any?, *>)
+  return FrameList<R, Any?, Any?>(list).asFramesCont(last as SplitSeq<Any?, *, *>)
 }
 
-internal fun findNearestSplitSeq(continuation: Continuation<*>): SplitSeq<*, *> {
+internal fun findNearestSplitSeq(continuation: Continuation<*>): SplitSeq<*, *, *> {
   continuation.forEach {
-    if (it is SplitSeq<*, *>) {
+    if (it is SplitSeq<*, *, *>) {
       return it
     }
   }
   error("No SplitSeq found in stack")
 }
 
-private fun <R> collectStack2(continuation: Continuation<R>): SplitSeq<R, *> {
+private fun <R> collectStack2(continuation: Continuation<R>): SplitSeq<R, *, *> {
   val list = mutableListOf<Continuation<*>>()
-  val last: SplitSeq<*, *> = run {
+  val last: SplitSeq<*, *, *> = run {
     continuation.forEach {
-      if (it is SplitSeq<*, *>) {
+      if (it is SplitSeq<*, *, *>) {
         return@run it
       }
       list.add(it.copy(EmptyContinuation(it.context)))
@@ -238,13 +247,13 @@ private fun <R> collectStack2(continuation: Continuation<R>): SplitSeq<R, *> {
     error("No SplitSeq found in stack")
   }
   return when {
-    list.isEmpty() -> last as SplitSeq<R, *>
+    list.isEmpty() -> last as SplitSeq<R, *, *>
     last is FramesCont<*, *, *, *> -> {
       list.addAll(last.frames.list)
-      FrameList<R, Any?, Any?>(list).asFramesCont(last.rest as SplitSeq<Any?, *>)
+      FrameList<R, Any?, Any?>(list).asFramesCont(last.rest as SplitSeq<Any?, *, *>)
     }
 
-    else -> FrameList<R, Any?, Any?>(list).asFramesCont(last as SplitSeq<Any?, *>)
+    else -> FrameList<R, Any?, Any?>(list).asFramesCont(last as SplitSeq<Any?, *, *>)
   }
 }
 

--- a/library/src/commonMain/kotlin/cloning.kt
+++ b/library/src/commonMain/kotlin/cloning.kt
@@ -146,10 +146,10 @@ internal tailrec fun <Start, End, S> SplitSeq<Start, *, End>.findOrNull(p: Reade
 }
 
 internal fun <Start, First, End, P> SplitSeq<Start, First, End>.splitAt(p: Prompt<P>): Pair<Segment<Start, *, P>, SplitSeq<P, *, End>> =
-  splitAtAux(p, emptySegment())
+  splitAtAux(p, EmptySegment)
 
 internal fun <Start, First, End> SplitSeq<Start, First, End>.splitAt(p: Reader<*>): Pair<Segment<Start, *, *>, SplitSeq<*, *, End>> =
-  splitAtAux(p, emptySegment())
+  splitAtAux(p, EmptySegment)
 
 internal fun <P, First, End> SplitSeq<P, First, End>.pushPrompt(p: Prompt<P>): PromptCont<P, First, End> =
   PromptCont(p, this)
@@ -226,15 +226,10 @@ internal tailrec infix fun <Start, First, End, FurtherEnd> Segment<Start, First,
     is FramesSegment<Start, First, *, *, End> -> init prependTo FramesCont(frames, stack)
 
     is PromptSegment<Start, First, End> -> init prependTo PromptCont(prompt, stack)
-    is ReaderSegment<*, Start, First, End> -> init prependTo toCont(stack)
+    is ReaderSegment<*, Start, First, End> -> init prependTo ReaderCont(prompt, fork(state), fork, stack)
   }
 
-private fun <State, Start, First, End, FurtherEnd> ReaderSegment<State, Start, First, End>.toCont(stack: SplitSeq<End, *, FurtherEnd>): ReaderCont<State, End, *, FurtherEnd> =
-  ReaderCont(prompt, fork(state), fork, stack)
-
-internal fun <T> emptySegment(): Segment<T, *, T> = EmptySegment as Segment<T, *, T>
-
-internal data object EmptySegment : Segment<Any?, Nothing, Any?>
+internal data object EmptySegment : Segment<Any?, Nothing, Nothing>
 
 internal data class FramesSegment<FurtherStart, FurtherFirst, Start, First, End>(
   val frames: FrameList<Start, First, End>, val init: Segment<FurtherStart, FurtherFirst, Start>

--- a/library/src/commonMain/kotlin/cloning.kt
+++ b/library/src/commonMain/kotlin/cloning.kt
@@ -7,21 +7,6 @@ internal expect val Continuation<*>.isCompilerGenerated: Boolean
 internal expect val Continuation<*>.completion: Continuation<*>
 internal expect fun <T> Continuation<T>.copy(completion: Continuation<*>): Continuation<T>
 
-private inline fun Continuation<*>.forEach(block: (Continuation<*>) -> Unit) {
-  var current: Continuation<*> = this
-  while (true) {
-    block(current)
-    current = when (current) {
-      in CompilerGenerated -> current.completion
-      else -> error("Continuation $current is not see-through, so its stack can't be traversed")
-    }
-  }
-}
-
-internal object CompilerGenerated {
-  operator fun contains(cont: Continuation<*>): Boolean = cont.isCompilerGenerated
-}
-
 @JvmInline
 internal value class Frame<in A, out B>(val cont: Continuation<A>) {
   fun resumeWith(value: Result<A>, into: Continuation<B>) = cont.copy(into).resumeWith(value)
@@ -73,7 +58,8 @@ private tailrec fun <Start, First, End> SplitSeq<Start, First, End>.resumeWithIm
       }
     } else {
       val wrapper = wrapperCont
-      wrapper.seq = rest as SplitSeq<Any?, *, *>?
+      val rest = rest!! as SplitSeq<Any?, *, *>
+      wrapper.seq = rest
       wrapper.realContext = rest.context
       if (isIntercepted) {
         wrapper.result = hasBeenIntercepted
@@ -92,9 +78,9 @@ private tailrec fun <Start, First, End> SplitSeq<Start, First, End>.resumeWithIm
       }
     }
 
-    is PromptCont -> rest.resumeWithImpl(result, isIntercepted = isIntercepted)
+    is PromptCont -> rest!!.resumeWithImpl(result, isIntercepted = isIntercepted)
 
-    is ReaderCont<*, Start, First, End> -> rest.resumeWithImpl(result, isIntercepted = isIntercepted)
+    is ReaderCont<*, Start, First, End> -> rest!!.resumeWithImpl(result, isIntercepted = isIntercepted)
   }
 }
 
@@ -102,71 +88,94 @@ internal tailrec fun <Start, First, End, P, FurtherStart, FurtherFirst> SplitSeq
   p: Prompt<P>, seg: Segment<FurtherStart, FurtherFirst, Start>
 ): Pair<Segment<FurtherStart, FurtherFirst, P>, SplitSeq<P, *, End>> = when (this) {
   is EmptyCont -> error("Prompt not found $p in $seg")
-  is FramesCont<Start, First, *, End> -> rest.splitAtAux(p, FramesSegment(frames, seg))
+  is FramesCont<Start, First, *, End> -> (rest!! as SplitSeq<Any?, *, End>).splitAtAux(p, FramesSegment(frames, seg))
   is PromptCont -> if (p === this.p) {
     // Start and P are now unified, but the compiler doesn't get it
-    val pair: Pair<Segment<FurtherStart, FurtherFirst, Start>, SplitSeq<Start, *, End>> = seg to rest
+    val pair: Pair<Segment<FurtherStart, FurtherFirst, Start>, SplitSeq<Start, *, End>> = seg to rest!!
     @Suppress("UNCHECKED_CAST")
     pair as Pair<Segment<FurtherStart, FurtherFirst, P>, SplitSeq<P, *, End>>
   } else {
-    rest.splitAtAux(p, PromptSegment(this.p, seg))
+    rest!!.splitAtAux(p, PromptSegment(this.p, seg))
   }
 
-  is ReaderCont<*, Start, First, End> -> rest.splitAtAux(p, toSegment(seg))
+  is ReaderCont<*, Start, First, End> -> rest!!.splitAtAux(p, toSegment(seg))
 }
 
 private fun <State, Start, First, End, FurtherStart, FurtherFirst> ReaderCont<State, Start, First, End>.toSegment(seg: Segment<FurtherStart, FurtherFirst, Start>): ReaderSegment<State, FurtherStart, FurtherFirst, Start> =
   ReaderSegment(p, state, fork, seg)
 
-internal tailrec fun <Start, First, End, FurtherStart, FurtherFirst> SplitSeq<Start, First, End>.splitAtAux(
-  p: Reader<*>, seg: Segment<FurtherStart, FurtherFirst, Start>
-): Pair<Segment<FurtherStart, FurtherFirst, *>, SplitSeq<*, *, End>> = when (this) {
-  is EmptyCont -> error("Prompt not found $p in $seg")
-  is FramesCont<Start, First, *, End> -> rest.splitAtAux(p, FramesSegment(frames, seg))
-  is PromptCont -> rest.splitAtAux(p, PromptSegment(this.p, seg))
-  is ReaderCont<*, Start, First, End> -> if (p === this.p) {
-    seg to rest
-  } else rest.splitAtAux(p, toSegment(seg))
+internal tailrec fun <Start, First, End> SplitSeq<Start, First, End>.deleteReader(
+  p: Reader<*>, previous: ExpectsSequenceStartingWith<*>
+): Unit = when (this) {
+  is EmptyCont -> error("Reader not found $p")
+  is FramesCont<Start, *, *, End> -> rest!!.deleteReader(p, this)
+  is PromptCont -> rest!!.deleteReader(p, this)
+  is ReaderCont<*, Start, *, End> -> if (p === this.p) {
+    previous as ExpectsSequenceStartingWith<Start>
+    previous.sequence = rest!!
+  } else rest!!.deleteReader(p, this)
 }
 
 internal tailrec fun <Start, End, P> SplitSeq<Start, *, End>.find(p: Prompt<P>): SplitSeq<P, *, End> = when (this) {
   is EmptyCont -> error("Prompt not found $p")
 
-  is FramesCont<Start, *, *, End> -> rest.find(p)
+  is FramesCont<Start, *, *, End> -> rest!!.find(p)
   is PromptCont -> if (p === this.p) {
     // Start and P are now unified, but the compiler doesn't get it
     @Suppress("UNCHECKED_CAST")
-    this.rest as SplitSeq<P, *, End>
-  } else rest.find(p)
+    this.rest!! as SplitSeq<P, *, End>
+  } else rest!!.find(p)
 
-  is ReaderCont<*, Start, *, End> -> rest.find(p)
+  is ReaderCont<*, Start, *, End> -> rest!!.find(p)
+}
+
+internal tailrec fun <Start, End, P> SplitSeq<Start, *, End>.findGuyBefore(
+  p: Prompt<P>,
+  previous: ExpectsSequenceStartingWith<Start>?
+): ExpectsSequenceStartingWith<P>? = when (this) {
+  is EmptyCont -> error("Prompt not found $p")
+
+  is FramesCont<Start, *, *, End> -> (rest!! as SplitSeq<Any?, *, End>).findGuyBefore(p, this)
+  is PromptCont -> if (p === this.p) {
+    // Start and P are now unified, but the compiler doesn't get it
+    @Suppress("UNCHECKED_CAST")
+    previous as ExpectsSequenceStartingWith<P>?
+  } else rest!!.findGuyBefore(p, this)
+
+  is ReaderCont<*, Start, *, End> -> rest!!.findGuyBefore(p, this)
 }
 
 internal tailrec fun <Start, End, S> SplitSeq<Start, *, End>.find(p: Reader<S>): S = when (this) {
   is EmptyCont -> error("Reader not found $p")
-  is FramesCont<Start, *, *, End> -> rest.find(p)
-  is PromptCont -> rest.find(p)
+  is FramesCont<Start, *, *, End> -> rest!!.find(p)
+  is PromptCont -> rest!!.find(p)
   is ReaderCont<*, Start, *, End> -> if (p === this.p) {
     @Suppress("UNCHECKED_CAST")
     this.state as S
-  } else rest.find(p)
+  } else rest!!.find(p)
 }
 
 internal tailrec fun <Start, End, S> SplitSeq<Start, *, End>.findOrNull(p: Reader<S>): S? = when (this) {
   is EmptyCont -> null
-  is FramesCont<Start, *, *, End> -> rest.findOrNull(p)
-  is PromptCont -> rest.findOrNull(p)
+  is FramesCont<Start, *, *, End> -> rest!!.findOrNull(p)
+  is PromptCont -> rest!!.findOrNull(p)
   is ReaderCont<*, Start, *, End> -> if (p === this.p) {
     @Suppress("UNCHECKED_CAST")
     this.state as S
-  } else rest.findOrNull(p)
+  } else rest!!.findOrNull(p)
 }
 
 internal fun <Start, First, End, P> SplitSeq<Start, First, End>.splitAt(p: Prompt<P>): Pair<Segment<Start, *, P>, SplitSeq<P, *, End>> =
   splitAtAux(p, EmptySegment)
 
-internal fun <Start, First, End> SplitSeq<Start, First, End>.splitAt(p: Reader<*>): Pair<Segment<Start, *, *>, SplitSeq<*, *, End>> =
-  splitAtAux(p, EmptySegment)
+internal fun <Start, First, End, P> SplitSeq<Start, First, End>.splitAtOnce(p: Prompt<P>): Pair<Segment<Start, *, P>, SplitSeq<P, *, End>> {
+  val box = findGuyBefore(p, null)
+  return if (box != null) {
+    SingleUseSegment(box, this) to box.sequence!!.also { box.sequence = null } as SplitSeq<P, *, End>
+  } else {
+    EmptySegment to this as SplitSeq<P, *, End>
+  }
+}
 
 internal fun <P, First, End> SplitSeq<P, First, End>.pushPrompt(p: Prompt<P>): PromptCont<P, First, End> =
   PromptCont(p, this)
@@ -181,9 +190,9 @@ internal data class EmptyCont<Start>(val underlying: Continuation<Start>) : Spli
 
 // frame :: frames ::: rest
 internal data class FramesCont<Start, First, Last, End>(
-  val frames: FrameList<Start, First, Last>, val rest: SplitSeq<Last, *, End>,
-  val wrapperCont: WrapperCont<*>?,
-) : SplitSeq<Start, First, End> {
+  val frames: FrameList<Start, First, Last>, var rest: SplitSeq<Last, *, End>?,
+  val wrapperCont: WrapperCont<Last>?,
+) : SplitSeq<Start, First, End>, ExpectsSequenceStartingWith<Last> {
   val head get() = frames.head()
 
   @Suppress("UNCHECKED_CAST")
@@ -191,32 +200,27 @@ internal data class FramesCont<Start, First, Last, End>(
     get() = frames.tail()?.let { FramesCont(it, rest, wrapperCont) }
       ?: rest as SplitSeq<First, *, End> // First == Last, but the compiler doesn't get it
 
-  override val context: CoroutineContext = rest.context
+  override val context: CoroutineContext = rest!!.context
+  override var sequence: SplitSeq<Last, *, *>?
+    get() = rest
+    set(value) {
+      rest = value as SplitSeq<Last, *, End>?
+    }
 }
 
-internal class WrapperContContext(val wrapper: WrapperCont<*>) : CoroutineContext {
-  private val context get() = wrapper.realContext
-  // TODO improve these implementations
-  override fun <R> fold(initial: R, operation: (R, CoroutineContext.Element) -> R): R =
-    this.context.fold(initial, operation)
+internal fun CoroutineContext.unwrap(): CoroutineContext =
+  if (this is WrapperCont<*>) this.realContext else this
 
-  override fun plus(context: CoroutineContext): CoroutineContext = this.context.plus(context)
-
-  override fun minusKey(key: CoroutineContext.Key<*>): CoroutineContext =
-    this.context.minusKey(key)
-
-  override fun <E : CoroutineContext.Element> get(key: CoroutineContext.Key<E>): E? =
-    this.context.get(key)
-
-  override fun equals(other: Any?): Boolean = context == other
-  override fun hashCode(): Int = context.hashCode()
-}
-
-internal class WrapperCont<T>(seq: SplitSeq<T, *, *>, isWaitingForValue: Boolean = false) : Continuation<T> {
+internal class WrapperCont<T>(seq: SplitSeq<T, *, *>, isWaitingForValue: Boolean = false) : Continuation<T>,
+  CoroutineContext {
   var seq: SplitSeq<T, *, *>? = seq
   var result: Result<T> = if (isWaitingForValue) waitingForValue else hasBeenIntercepted
-  var realContext = seq.context
-  override val context: CoroutineContext = WrapperContContext(this)
+  var realContext = seq.context.unwrap()
+    set(value) {
+      field = value.unwrap()
+    }
+
+  override val context: CoroutineContext get() = this
 
   override fun resumeWith(result: Result<T>) {
     if (this.result == waitingForValue) {
@@ -225,6 +229,18 @@ internal class WrapperCont<T>(seq: SplitSeq<T, *, *>, isWaitingForValue: Boolean
       seq!!.resumeWith(result, isIntercepted = false)
     }
   }
+
+  // TODO improve these implementations
+  override fun <R> fold(initial: R, operation: (R, CoroutineContext.Element) -> R): R =
+    realContext.fold(initial, operation)
+
+  override fun plus(context: CoroutineContext): CoroutineContext = realContext.plus(context)
+
+  override fun minusKey(key: CoroutineContext.Key<*>): CoroutineContext =
+    realContext.minusKey(key)
+
+  override fun <E : CoroutineContext.Element> get(key: CoroutineContext.Key<E>): E? =
+    realContext.get(key)
 }
 
 private data object WaitingForValue : Throwable()
@@ -236,15 +252,26 @@ private data object HasBeenIntercepted : Throwable()
 private val hasBeenIntercepted = Result.failure<Nothing>(HasBeenIntercepted)
 
 internal data class PromptCont<Start, First, End>(
-  val p: Prompt<Start>, val rest: SplitSeq<Start, First, End>
-) : SplitSeq<Start, First, End> {
-  override val context = rest.context
+  val p: Prompt<Start>, var rest: SplitSeq<Start, First, End>?
+) : SplitSeq<Start, First, End>, ExpectsSequenceStartingWith<Start> {
+  override val context = rest!!.context
+  override var sequence: SplitSeq<Start, *, *>?
+    get() = rest
+    set(value) {
+      rest = value as SplitSeq<Start, First, End>?
+    }
 }
 
 internal data class ReaderCont<State, Start, First, End>(
-  val p: Reader<State>, val state: State, val fork: State.() -> State, val rest: SplitSeq<Start, First, End>
-) : SplitSeq<Start, First, End> {
-  override val context = rest.context
+  val p: Reader<State>, val state: State, val fork: State.() -> State, var rest: SplitSeq<Start, First, End>?
+) : SplitSeq<Start, First, End>, ExpectsSequenceStartingWith<Start> {
+  override val context = rest!!.context
+
+  override var sequence: SplitSeq<Start, *, *>?
+    get() = rest
+    set(value) {
+      rest = value as SplitSeq<Start, First, End>?
+    }
 }
 
 // sub continuations / stack segments
@@ -263,6 +290,11 @@ internal tailrec infix fun <Start, First, End, FurtherEnd> Segment<Start, First,
 
     is PromptSegment<Start, First, End> -> init prependTo PromptCont(prompt, stack)
     is ReaderSegment<*, Start, First, End> -> init prependTo ReaderCont(prompt, fork(state), fork, stack)
+
+    is SingleUseSegment<Start, First, End> -> {
+      box.sequence = stack
+      cont as SplitSeq<Start, *, FurtherEnd>
+    }
   }
 
 internal data object EmptySegment : Segment<Any?, Nothing, Nothing>
@@ -279,15 +311,25 @@ internal data class ReaderSegment<State, Start, First, End>(
   val prompt: Reader<State>, val state: State, val fork: (State.() -> State), val init: Segment<Start, First, End>
 ) : Segment<Start, First, End>
 
-internal fun <R> collectStack(continuation: Continuation<R>): SplitSeq<R, *, *> {
-  val wrapper: WrapperCont<*> = findNearestWrapperCont(continuation)
-  val seq = wrapper.seq!!
-  wrapper.seq = null
-  return FramesCont(FrameList<R, Any?, Nothing>(Frame(continuation)), seq, wrapper)
+// Expects that cont eventually refers to box
+internal data class SingleUseSegment<Start, First, End>(
+  val box: ExpectsSequenceStartingWith<End>, val cont: SplitSeq<Start, First, *>
+) : Segment<Start, First, End>
+
+internal sealed interface ExpectsSequenceStartingWith<Start> {
+  var sequence: SplitSeq<Start, *, *>?
 }
+
+internal fun <R> collectStack(continuation: Continuation<R>): SplitSeq<R, *, *> =
+  findNearestWrapperCont(continuation).toFramesCont(continuation)
+
+private fun <R, T> WrapperCont<T>.toFramesCont(
+  continuation: Continuation<R>
+): FramesCont<R, Any?, T, Any?> =
+  FramesCont(FrameList(Frame(continuation)), seq!!.also { seq = null }, this)
 
 internal fun findNearestSplitSeq(continuation: Continuation<*>): SplitSeq<*, *, *> =
   findNearestWrapperCont(continuation).seq!!
 
 private fun findNearestWrapperCont(continuation: Continuation<*>): WrapperCont<*> =
-  (continuation.context as? WrapperContContext)?.wrapper ?: error("No WrapperCont found in stack")
+  continuation.context as? WrapperCont<*> ?: error("No WrapperCont found in stack")

--- a/library/src/commonMain/kotlin/effekt/handler.kt
+++ b/library/src/commonMain/kotlin/effekt/handler.kt
@@ -14,7 +14,6 @@ public interface Handler<E> {
 }
 
 public interface StatefulHandler<E, S> : Handler<E> {
-  override fun prompt(): HandlerPrompt<E>
   public val reader: Reader<S>
 }
 

--- a/library/src/commonMain/kotlin/effekt/handler.kt
+++ b/library/src/commonMain/kotlin/effekt/handler.kt
@@ -4,10 +4,13 @@ import Prompt
 import Reader
 import abortS0
 import abortWith0
+import abortWithFast
 import ask
 import pushReader
 import reset
 import takeSubCont
+import takeSubContOnce
+import takeSubContWithFinal
 import kotlin.jvm.JvmInline
 
 public interface Handler<E> {
@@ -20,13 +23,26 @@ public interface StatefulHandler<E, S> : Handler<E> {
 
 public suspend fun <E, S> StatefulHandler<E, S>.get(): S = reader.ask()
 
-public suspend inline fun <A, E> Handler<E>.use(crossinline body: suspend (Cont<A, E>) -> E): A = prompt().prompt.takeSubCont { sk ->
-  body(Cont(sk))
-}
+public suspend inline fun <A, E> Handler<E>.use(crossinline body: suspend (Cont<A, E>) -> E): A =
+  prompt().prompt.takeSubCont { sk ->
+    body(Cont(sk))
+  }
+
+public suspend inline fun <A, E> Handler<E>.useOnce(crossinline body: suspend (Cont<A, E>) -> E): A =
+  prompt().prompt.takeSubContOnce { sk ->
+    body(Cont(sk))
+  }
+
+public suspend inline fun <A, E> Handler<E>.useWithFinal(crossinline body: suspend (Pair<Cont<A, E>, Cont<A, E>>) -> E): A =
+  prompt().prompt.takeSubContWithFinal { sk ->
+    body(Cont(sk.first) to Cont(sk.second))
+  }
 
 public fun <E> Handler<E>.discard(body: suspend () -> E): Nothing = prompt().prompt.abortS0(body)
 
 public fun <E> Handler<E>.discardWith(value: Result<E>): Nothing = prompt().prompt.abortWith0(value)
+
+public suspend fun <E> Handler<E>.discardWithFast(value: Result<E>): Nothing = prompt().prompt.abortWithFast(deleteDelimiter = true, value)
 
 public suspend fun <E, H> handle(
   handler: ((() -> HandlerPrompt<E>) -> H), body: suspend H.() -> E
@@ -76,9 +92,12 @@ public value class Cont<in T, out R> @PublishedApi internal constructor(internal
   public suspend fun resumeWith(value: Result<T>, shouldClear: Boolean = false): R =
     subCont.pushSubContWith(value, isDelimiting = true, shouldClear)
 
-  public suspend operator fun invoke(value: T, shouldClear: Boolean = false): R = resumeWith(Result.success(value), shouldClear)
+  public suspend operator fun invoke(value: T, shouldClear: Boolean = false): R =
+    resumeWith(Result.success(value), shouldClear)
 
   public suspend fun resumeWithException(exception: Throwable, shouldClear: Boolean = false): R =
     resumeWith(Result.failure(exception), shouldClear)
+
   public fun copy(): Cont<T, R> = Cont(subCont.copy())
+  public fun clear() { subCont.clear() }
 }

--- a/library/src/commonMain/kotlin/effekt/handler.kt
+++ b/library/src/commonMain/kotlin/effekt/handler.kt
@@ -49,10 +49,11 @@ public suspend fun <E, H> handle(
 ): E = handle { handler { this }.body() }
 
 public suspend fun <E> handle(body: suspend HandlerPrompt<E>.() -> E): E = with(HandlerPrompt<E>()) {
-  handle { body() }
+  rehandle { body() }
 }
 
-public suspend fun <E> Handler<E>.handle(body: suspend () -> E): E = prompt().prompt.reset(body)
+// TODO maybe we should remove this? Effekt gets by without it (but their lambdas are restricted)
+public suspend fun <E> Handler<E>.rehandle(body: suspend () -> E): E = prompt().prompt.reset(body)
 
 public suspend fun <E, H : StatefulHandler<E, S>, S> handleStateful(
   handler: ((() -> StatefulPrompt<E, S>) -> H), value: S, fork: S.() -> S,
@@ -60,16 +61,16 @@ public suspend fun <E, H : StatefulHandler<E, S>, S> handleStateful(
 ): E {
   val p = StatefulPrompt<E, S>()
   val h = handler { p }
-  return h.handleStateful(value, fork) { h.body() }
+  return h.rehandleStateful(value, fork) { h.body() }
 }
 
 public suspend fun <E, S> handleStateful(
   value: S, fork: S.() -> S, body: suspend StatefulPrompt<E, S>.() -> E
 ): E = with(StatefulPrompt<E, S>()) {
-  handleStateful(value, fork) { body() }
+  rehandleStateful(value, fork) { body() }
 }
 
-public suspend fun <E, S> StatefulHandler<E, S>.handleStateful(
+public suspend fun <E, S> StatefulHandler<E, S>.rehandleStateful(
   value: S, fork: S.() -> S,
   body: suspend () -> E
 ): E = reader.pushReader(value, fork) {

--- a/library/src/commonMain/kotlin/effekt/handler.kt
+++ b/library/src/commonMain/kotlin/effekt/handler.kt
@@ -73,12 +73,12 @@ public class StatefulPrompt<E, S>(
 
 @JvmInline
 public value class Cont<in T, out R> @PublishedApi internal constructor(internal val subCont: SubCont<T, R>) {
-  public suspend fun resumeWith(value: Result<T>, isFinal: Boolean = false): R =
-    subCont.pushSubContWith(value, isDelimiting = true, isFinal)
+  public suspend fun resumeWith(value: Result<T>, shouldClear: Boolean = false): R =
+    subCont.pushSubContWith(value, isDelimiting = true, shouldClear)
 
-  public suspend operator fun invoke(value: T, isFinal: Boolean = false): R = resumeWith(Result.success(value), isFinal)
+  public suspend operator fun invoke(value: T, shouldClear: Boolean = false): R = resumeWith(Result.success(value), shouldClear)
 
-  public suspend fun resumeWithException(exception: Throwable, isFinal: Boolean = false): R =
-    resumeWith(Result.failure(exception), isFinal)
+  public suspend fun resumeWithException(exception: Throwable, shouldClear: Boolean = false): R =
+    resumeWith(Result.failure(exception), shouldClear)
   public fun copy(): Cont<T, R> = Cont(subCont.copy())
 }

--- a/library/src/commonMain/kotlin/effekt/state.kt
+++ b/library/src/commonMain/kotlin/effekt/state.kt
@@ -1,7 +1,8 @@
 package effekt
 
-import pushState
+import State
 import get
+import pushState
 import set
 
 public interface StateScope {
@@ -20,17 +21,35 @@ public suspend fun <R> region(body: suspend StateScope.() -> R): R = handle {
   body(StateScopeImpl(this))
 }
 
+// TODO use map implementation
 private class StateScopeImpl<R>(prompt: HandlerPrompt<R>) : StateScope, Handler<R> by prompt {
-  override suspend fun <T> field(init: T): StateScope.Field<T> = FieldImpl<T>().apply {
+  override suspend fun <T> field(init: T): StateScope.Field<T> = FieldImpl<T>(State()).apply {
     use {
-      pushState(init) {
+      state.pushState(init) {
         it(Unit)
       }
     }
   }
 
-  private class FieldImpl<T> : StateScope.Field<T>, State<T> {
-    override suspend fun get(): T = (this as State<T>).get()
-    override suspend fun set(value: T) = (this as State<T>).set(value)
+  private data class FieldImpl<T>(val state: State<T>) : StateScope.Field<T> {
+    override suspend fun get(): T = state.get()
+    override suspend fun set(value: T) = state.set(value)
   }
 }
+
+public interface Stateful<S : Stateful<S>> {
+  public fun fork(): S
+}
+
+public suspend fun <E, H : StatefulHandler<E, S>, S : Stateful<S>> handleStateful(
+  handler: ((() -> StatefulPrompt<E, S>) -> H), value: S,
+  body: suspend H.() -> E
+): E = handleStateful(handler, value, Stateful<S>::fork, body)
+
+public suspend fun <E, S : Stateful<S>> handleStateful(
+  value: S, body: suspend StatefulPrompt<E, S>.() -> E
+): E = handleStateful(value, Stateful<S>::fork, body)
+
+public suspend fun <E, S : Stateful<S>> StatefulHandler<E, S>.handleStateful(
+  value: S, body: suspend () -> E
+): E = handleStateful(value, Stateful<S>::fork, body)

--- a/library/src/commonMain/kotlin/effekt/state.kt
+++ b/library/src/commonMain/kotlin/effekt/state.kt
@@ -50,6 +50,6 @@ public suspend fun <E, S : Stateful<S>> handleStateful(
   value: S, body: suspend StatefulPrompt<E, S>.() -> E
 ): E = handleStateful(value, Stateful<S>::fork, body)
 
-public suspend fun <E, S : Stateful<S>> StatefulHandler<E, S>.handleStateful(
+public suspend fun <E, S : Stateful<S>> StatefulHandler<E, S>.rehandleStateful(
   value: S, body: suspend () -> E
-): E = handleStateful(value, Stateful<S>::fork, body)
+): E = rehandleStateful(value, Stateful<S>::fork, body)

--- a/library/src/commonMain/kotlin/reader.kt
+++ b/library/src/commonMain/kotlin/reader.kt
@@ -1,9 +1,12 @@
-import kotlin.coroutines.coroutineContext
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 
-public suspend fun <T> Reader<T>.ask(): T = (coroutineContext[this] ?: error("Reader $this not set")).state
-public suspend fun <T> Reader<T>.askOrNull(): T? = coroutineContext[this]?.state
+public suspend fun <T> Reader<T>.ask(): T = suspendCoroutineUninterceptedOrReturn {
+  findNearestSplitSeq(it).find(this)
+}
 
-public suspend fun Reader<*>.isSet(): Boolean = coroutineContext[this] != null
+public suspend fun <T> Reader<T>.askOrNull(): T? = suspendCoroutineUninterceptedOrReturn {
+  findNearestSplitSeq(it).findOrNull(this)
+}
 
 public suspend fun <T, R> runReader(value: T, fork: T.() -> T = { this }, body: suspend Reader<T>.() -> R): R =
   with(Reader<T>()) {

--- a/library/src/commonMain/kotlin/reader.kt
+++ b/library/src/commonMain/kotlin/reader.kt
@@ -1,45 +1,11 @@
-import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.coroutineContext
 
-public class ReaderValue<T>(public val value: T, override val key: Reader<T>) : CoroutineContext.Element
-
-public interface Reader<T> : CoroutineContext.Key<ReaderValue<T>>
-
-public fun <T> Reader(): Reader<T> = object : Reader<T> {}
-
-public suspend fun <T> Reader<T>.ask(): T = (coroutineContext[this] ?: error("Reader $this not set")).value
-public suspend fun <T> Reader<T>.askOrNull(): T? = coroutineContext[this]?.value
+public suspend fun <T> Reader<T>.ask(): T = (coroutineContext[this] ?: error("Reader $this not set")).state
+public suspend fun <T> Reader<T>.askOrNull(): T? = coroutineContext[this]?.state
 
 public suspend fun Reader<*>.isSet(): Boolean = coroutineContext[this] != null
 
-public suspend fun <T, R> runReader(value: T, body: suspend Reader<T>.() -> R): R {
-  val reader = Reader<T>()
-  return reader.pushReader(value) { reader.body() }
-}
-
-public suspend fun <T, R> runForkingReader(value: T, fork: T.() -> T, body: suspend Reader<T>.() -> R): R =
+public suspend fun <T, R> runReader(value: T, fork: T.() -> T = { this }, body: suspend Reader<T>.() -> R): R =
   with(Reader<T>()) {
-    pushForkingReader(value, fork) { body() }
+    pushReader(value, fork) { body() }
   }
-
-public suspend fun <T, R> Reader<T>.pushForkingReader(value: T, fork: T.() -> T, body: suspend () -> R): R =
-  pushContext(
-    context = context(value), rewindHandler = RewindHandler { oldProducedContext, _ ->
-      context(oldProducedContext[this]!!.value.fork())
-    }, body = body
-  )
-
-public suspend fun <T, R> Reader<T>.pushReader(value: T, body: suspend () -> R): R = pushContext(
-  context = context(value), rewindHandler = null, body = body
-)
-
-// TODO this is non-standard and a bad attempt at implementing `local`
-// Investigate if any legitimate use-cases exist for this
-public suspend fun <T, R> Reader<T>.mapReader(map: (T) -> T, body: suspend () -> R): R = pushContext(
-  context = context(map(ask())), rewindHandler = RewindHandler { _, newParentContext ->
-    context(map(newParentContext[this]!!.value))
-  }, body = body
-)
-
-// TODO we could probably make this public
-internal fun <T> Reader<T>.context(value: T): CoroutineContext.Element = ReaderValue<T>(value, this)

--- a/library/src/commonMain/kotlin/reset.kt
+++ b/library/src/commonMain/kotlin/reset.kt
@@ -50,7 +50,7 @@ public suspend fun <R> Prompt<R>.pushPrompt(
   body.startCoroutine(WrapperCont(stack.pushPrompt(this)))
 }
 
-/*
+/* TODO this might be better
 suspendCoroutineUnintercepted { k ->
   val stack = collectStack(k).pushPrompt(this)
   stack.resumeWith(runCatching {

--- a/library/src/commonMain/kotlin/reset.kt
+++ b/library/src/commonMain/kotlin/reset.kt
@@ -13,7 +13,7 @@ public class SubCont<in T, out R> internal constructor(
 ) {
   private fun composedWith(
     k: Continuation<R>, isDelimiting: Boolean, isFinal: Boolean
-  ) = (init!! prependTo collectStack(k).let { if (isDelimiting) it.pushPrompt(prompt) else it.intercepted() }).also {
+  ) = (init!! prependTo collectStack(k).let { if (isDelimiting) it.pushPrompt(prompt) else it }).also {
     if (isFinal) init = null
   }
 
@@ -23,7 +23,7 @@ public class SubCont<in T, out R> internal constructor(
     isDelimiting: Boolean = false,
     isFinal: Boolean = false,
   ): R = suspendCoroutineUnintercepted { k ->
-    composedWith(k, isDelimiting, isFinal).resumeWith(value)
+    composedWith(k, isDelimiting, isFinal).resumeWith(value, isIntercepted = true)
   }
 
   @ResetDsl

--- a/library/src/commonMain/kotlin/reset.kt
+++ b/library/src/commonMain/kotlin/reset.kt
@@ -13,7 +13,7 @@ public class SubCont<in T, out R> internal constructor(
 ) {
   private fun composedWith(
     k: Continuation<R>, isDelimiting: Boolean, isFinal: Boolean
-  ) = (init!! prependTo collectStack(k).let { if (isDelimiting) it.pushPrompt(prompt) else it }).also {
+  ) = (init!! prependTo collectStack(k).let { if (isDelimiting) it.pushPrompt(prompt) else it.intercepted() }).also {
     if (isFinal) init = null
   }
 

--- a/library/src/commonMain/kotlin/reset.kt
+++ b/library/src/commonMain/kotlin/reset.kt
@@ -12,27 +12,27 @@ public class SubCont<in T, out R> internal constructor(
   private val prompt: Prompt<R>
 ) {
   private fun composedWith(
-    k: Continuation<R>, isDelimiting: Boolean, isFinal: Boolean
+    k: Continuation<R>, isDelimiting: Boolean, shouldClear: Boolean
   ) = (init!! prependTo collectStack(k).let { if (isDelimiting) it.pushPrompt(prompt) else it }).also {
-    if (isFinal) init = null
+    if (shouldClear) init = null
   }
 
   @ResetDsl
   public suspend fun pushSubContWith(
     value: Result<T>,
     isDelimiting: Boolean = false,
-    isFinal: Boolean = false,
+    shouldClear: Boolean = false,
   ): R = suspendCoroutineUnintercepted { k ->
-    composedWith(k, isDelimiting, isFinal).resumeWith(value, isIntercepted = true)
+    composedWith(k, isDelimiting, shouldClear).resumeWith(value, isIntercepted = true)
   }
 
   @ResetDsl
   public suspend fun pushSubCont(
     isDelimiting: Boolean = false,
-    isFinal: Boolean = false,
+    shouldClear: Boolean = false,
     value: suspend () -> T
   ): R = suspendCoroutineUnintercepted { k ->
-    value.startCoroutine(composedWith(k, isDelimiting, isFinal))
+    value.startCoroutine(composedWith(k, isDelimiting, shouldClear))
   }
 
   public fun copy(): SubCont<T, R> = SubCont(init, prompt)

--- a/library/src/commonMain/kotlin/resetDsl.kt
+++ b/library/src/commonMain/kotlin/resetDsl.kt
@@ -20,10 +20,9 @@ public suspend inline fun <T, R> Prompt<R>.shift(crossinline block: suspend (Con
 public suspend inline fun <T, R> Prompt<R>.control(crossinline block: suspend (Cont<T, R>) -> R): T =
   takeSubCont(deleteDelimiter = false) { sk -> block { sk.pushSubContWith(it) } }
 
-// TODO should we be reinstating context like that? Should we reinstate more stuff?
 @ResetDsl
 public suspend inline fun <T, R> Prompt<R>.shift0(crossinline block: suspend (Cont<T, R>) -> R): T =
-  takeSubCont { sk -> block { sk.pushSubContWith(it, isDelimiting = true, extraContext = sk.extraContext) } }
+  takeSubCont { sk -> block { sk.pushSubContWith(it, isDelimiting = true) } }
 
 @ResetDsl
 public suspend inline fun <T, R> Prompt<R>.control0(crossinline block: suspend (Cont<T, R>) -> R): T =

--- a/library/src/commonMain/kotlin/resetDsl.kt
+++ b/library/src/commonMain/kotlin/resetDsl.kt
@@ -17,6 +17,10 @@ public suspend inline fun <T, R> Prompt<R>.shift(crossinline block: suspend (Con
   takeSubCont(deleteDelimiter = false) { sk -> block { sk.pushSubContWith(it, isDelimiting = true) } }
 
 @ResetDsl
+public suspend inline fun <T, R> Prompt<R>.shiftOnce(crossinline block: suspend (Cont<T, R>) -> R): T =
+  takeSubContOnce(deleteDelimiter = false) { sk -> block { sk.pushSubContWith(it, isDelimiting = true) } }
+
+@ResetDsl
 public suspend inline fun <T, R> Prompt<R>.control(crossinline block: suspend (Cont<T, R>) -> R): T =
   takeSubCont(deleteDelimiter = false) { sk -> block { sk.pushSubContWith(it) } }
 

--- a/library/src/commonMain/kotlin/stackState.kt
+++ b/library/src/commonMain/kotlin/stackState.kt
@@ -1,18 +1,12 @@
-import arrow.atomic.Atomic
-import arrow.atomic.update
-import arrow.atomic.value
-
 public typealias StackState<T> = State<List<T>>
 
-public suspend fun <T> StackState<T>.set(value: T) = ask().update { it + value }
-public suspend fun <T> StackState<T>.get() = ask().value.last()
+public suspend operator fun <T> StackState<T>.plusAssign(value: T) = modify { it + value }
+public suspend fun <T> StackState<T>.getLast() = ask().value.last()
 
-public suspend inline fun <T> StackState<T>.modify(f: (T) -> T) = ask().update { it + f(it.last()) }
+public suspend inline fun <T> StackState<T>.modifyLast(f: (T) -> T) = plusAssign(f(getLast()))
 
-public suspend fun <T, R> runStackState(value: T, body: suspend StackState<T>.() -> R): R {
-  val state = Reader<Atomic<List<T>>>()
-  return state.pushStackState(value) { state.body() }
-}
+public suspend fun <T, R> runStackState(value: T, body: suspend StackState<T>.() -> R): R =
+  runState(listOf(value), body)
 
 public suspend fun <T, R> StackState<T>.pushStackState(value: T, body: suspend () -> R): R =
   pushState(listOf(value), body)

--- a/library/src/commonTest/kotlin/ContinuationTest.kt
+++ b/library/src/commonTest/kotlin/ContinuationTest.kt
@@ -4,6 +4,7 @@ import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.testTimeSource
 import kotlin.test.Test
@@ -129,18 +130,18 @@ class ContinuationTest {
   }
 
   @Test
-  fun stackSafety() = runTest {
+  fun stackSafety() = runTest(UnconfinedTestDispatcher()) {
     val n = stackSafeIterations
     topReset<Int> {
       repeat(n) {
-        shift { k -> k(Unit) + it }
+        shiftOnce { k -> k(Unit) + it }
       }
       0
     } shouldBe n * (n - 1) / 2
   }
 
   @Test
-  fun manyIterations() = runTest {
+  fun manyIterations() = runTest(UnconfinedTestDispatcher()) {
     val n = 100_000
     val result = topReset<Int> {
       shift { k ->

--- a/library/src/commonTest/kotlin/ReaderTest.kt
+++ b/library/src/commonTest/kotlin/ReaderTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 
 class ReaderTest {
   @Test
-  fun simple() = runTest {
+  fun simple() = runTestCC {
     runReader(1) reader@{
       newReset reset@{
         pushReader(2) {

--- a/library/src/commonTest/kotlin/StateTest.kt
+++ b/library/src/commonTest/kotlin/StateTest.kt
@@ -33,11 +33,11 @@ class StateTest {
     data class CounterState(val count: Int)
 
     suspend fun StackState<CounterState>.incrementCounter() {
-      modify<CounterState> { state -> state.copy(count = state.count + 1) }
+      modifyLast<CounterState> { state -> state.copy(count = state.count + 1) }
     }
 
     suspend fun StackState<CounterState>.doubleCounter() {
-      modify<CounterState> { state -> state.copy(count = state.count * 2) }
+      modifyLast<CounterState> { state -> state.copy(count = state.count * 2) }
     }
 
     val result = runCC {

--- a/library/src/commonTest/kotlin/effekt/AwaitTest.kt
+++ b/library/src/commonTest/kotlin/effekt/AwaitTest.kt
@@ -7,11 +7,13 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import runCC
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.milliseconds
 
 class AwaitTest {
   @Test
+  @Ignore
   fun example() = runTest {
     val printed = StringBuilder()
     runCC {

--- a/library/src/commonTest/kotlin/effekt/AwaitTest.kt
+++ b/library/src/commonTest/kotlin/effekt/AwaitTest.kt
@@ -7,13 +7,11 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import runCC
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.milliseconds
 
 class AwaitTest {
   @Test
-  @Ignore
   fun example() = runTest {
     val printed = StringBuilder()
     runCC {

--- a/library/src/commonTest/kotlin/effekt/CoroutineTest.kt
+++ b/library/src/commonTest/kotlin/effekt/CoroutineTest.kt
@@ -126,7 +126,7 @@ class CoroutineInstance<In, Out, Result>(
   }
 
   suspend fun <Arg> start(body: CoroutineBody<In, Out, Arg, Result>, arg: Arg): CoroutineInstance<In, Out, Result> {
-    yielder.prompt().handle {
+    yielder.prompt().rehandle {
       yielder.state = CoroutineState.Done(body(arg, yielder))
     }
     state = yielder.state

--- a/library/src/commonTest/kotlin/effekt/FibersTest.kt
+++ b/library/src/commonTest/kotlin/effekt/FibersTest.kt
@@ -131,6 +131,13 @@ class Scheduler2(prompt: HandlerPrompt<Unit>) : Handler<Unit> by prompt {
     k(false, shouldClear = true)
   }
 
+  suspend inline fun forkFlipped(task: Task) {
+    if (!fork()) {
+      task()
+      discardWithFast(Result.success(Unit))
+    }
+  }
+
   suspend inline fun fork(task: Task) {
     // TODO this reveals an inefficiency in the SplitSeq code
     //  because here the frames up to the prompt are never used

--- a/library/src/commonTest/kotlin/effekt/FibersTest.kt
+++ b/library/src/commonTest/kotlin/effekt/FibersTest.kt
@@ -120,7 +120,7 @@ class CanSuspend<A>(prompt: HandlerPrompt<Unit>, private val fiber: CanResume<A>
 
 private fun makeTask(k: Cont<Boolean, Unit>): Task {
   val newK = k.copy()
-  return { newK(true, isFinal = true) }
+  return { newK(true, shouldClear = true) }
 }
 
 class Scheduler2(prompt: HandlerPrompt<Unit>) : Handler<Unit> by prompt {
@@ -128,8 +128,8 @@ class Scheduler2(prompt: HandlerPrompt<Unit>) : Handler<Unit> by prompt {
   suspend fun fork(): Boolean = use { k ->
     tasks.addLast(makeTask(k))
     // Kotlin compiler doesn't null the fields used for parameters,
-    // hence the `isFinal` is necessary to prevent memory leaks
-    k(false, isFinal = true)
+    // hence the `shouldClear` is necessary to prevent memory leaks
+    k(false, shouldClear = true)
   }
 
   suspend inline fun fork(task: Task) {
@@ -142,7 +142,7 @@ class Scheduler2(prompt: HandlerPrompt<Unit>) : Handler<Unit> by prompt {
   // Since we only run on one thread, we also need yield in the scheduler
   // to allow cooperative multitasking
   suspend fun yield() = use {
-    tasks.addLast { it(Unit, isFinal = true) }
+    tasks.addLast { it(Unit, shouldClear = true) }
   }
 
   // we can't run the scheduler in pure since the continuation that contains

--- a/library/src/commonTest/kotlin/effekt/FibersTest.kt
+++ b/library/src/commonTest/kotlin/effekt/FibersTest.kt
@@ -132,6 +132,11 @@ class Scheduler2(prompt: HandlerPrompt<Unit>) : Handler<Unit> by prompt {
   }
 
   suspend inline fun fork(task: Task) {
+    // TODO this reveals an inefficiency in the SplitSeq code
+    //  because here the frames up to the prompt are never used
+    //  so we should never have to copy them, but seemingly we copy
+    //  at least the SplitSeq elements by turning them into Segments
+    //  so maybe we can delay segment creation?
     if (fork()) {
       task()
       discardWithFast(Result.success(Unit))
@@ -139,7 +144,7 @@ class Scheduler2(prompt: HandlerPrompt<Unit>) : Handler<Unit> by prompt {
   }
 
   fun fastFork(task: Task) {
-    tasks.addLast { handle(task) }
+    tasks.addLast { rehandle(task) }
   }
 
   // Since we only run on one thread, we also need yield in the scheduler
@@ -159,8 +164,11 @@ class Scheduler2(prompt: HandlerPrompt<Unit>) : Handler<Unit> by prompt {
 }
 
 suspend fun scheduler2(block: suspend Scheduler2.() -> Unit) {
-  val s = Scheduler2(HandlerPrompt())
-  s.prompt().handle { block(s) }
+  lateinit var s: Scheduler2
+  handle {
+    s = Scheduler2(this)
+    block(s)
+  }
   // this is safe since all tasks container the scheduler prompt marker
   s.run()
 }

--- a/library/src/commonTest/kotlin/effekt/GeneratorTest.kt
+++ b/library/src/commonTest/kotlin/effekt/GeneratorTest.kt
@@ -74,15 +74,11 @@ fun interface EffectfulIterable<A> {
   suspend operator fun iterator(): EffectfulIterator<A>
 }
 
-fun <A> effectfulIterable(body: suspend Generator<A>.() -> Unit): EffectfulIterable<A> {
-  val prompt = HandlerPrompt<EffectfulIteratorStep<A>>()
-  val iterate = Iterate(prompt)
-  return EffectfulIterable<A> {
-    EffectfulIteratorImpl<A>(prompt.handle<EffectfulIteratorStep<A>> {
-      iterate.body()
-      EffectfulIteratorStep.Done
-    })
-  }
+fun <A> effectfulIterable(body: suspend Generator<A>.() -> Unit) = EffectfulIterable<A> {
+  EffectfulIteratorImpl<A>(handle {
+    body(Iterate(this))
+    EffectfulIteratorStep.Done
+  })
 }
 
 class EffectfulIteratorImpl<A>(var current: EffectfulIteratorStep<A>) : EffectfulIterator<A> {

--- a/library/src/commonTest/kotlin/effekt/Logic.kt
+++ b/library/src/commonTest/kotlin/effekt/Logic.kt
@@ -1,0 +1,244 @@
+package effekt
+
+import arrow.core.None
+import arrow.core.Option
+import arrow.core.Some
+import ask
+import runReader
+
+// wrap with a handle that'll allow turning the iteration into an iterator-like thing
+// should be handle, then stateful. Reuse loop as shown in the pdf. stateful should have
+// answer type of A, while the outer handle should be Pair
+// TODO if we make next nullable, we can detect the case where the queue has no more items
+//  and hence prevent the extra `raise` in every `choose` over a branch
+//  This seems to correspond to the `Tree` datatype from the LogicT paper
+data class Branch<A>(val value: A, val next: suspend () -> Branch<A>?)
+
+// TODO a lot of these directly would benefit from directly using Branch
+//  instead of choosing and splitting repeatedly
+
+// TODO we could emulate shallow handlers with state
+//  and thus split can be simpler, and can just return the list of jobs as List<suspend AmbExc.() -> A>
+
+suspend fun <A> split(block: suspend AmbExc.() -> A): Branch<A>? = handle split@{
+  runReader(ArrayDeque<suspend () -> A>(), ::ArrayDeque) {
+    ask().addFirst {
+      handle ambExc@{
+        block(object : AmbExc {
+          override suspend fun flip(): Boolean = use { resume ->
+            ask().addFirst { resume(false) }
+            resume(true)
+          }
+
+          override suspend fun raise(msg: String): Nothing = discard {
+            val branches = ask()
+            if (branches.isEmpty()) this@split.discardWithFast(Result.success(null))
+            else branches.removeFirst().invoke()
+          }
+        })
+      }
+    }
+    while (true) {
+      val branch = ask().removeFirstOrNull() ?: break
+      val result = branch()
+      use {
+        Branch(result) { it(Unit) }
+      }
+    }
+    null
+  }
+}
+
+suspend fun <A> AmbExc.choose(branch: suspend () -> Branch<A>?): A {
+  var branch = branch()
+  while (branch != null) {
+    if (flip()) return branch.value
+    branch = branch.next()
+  }
+  raise()
+}
+
+// TODO check name against LogicT paper
+suspend fun <A> AmbExc.reflect(branch: Branch<A>): A = if (flip()) branch.value else choose(branch.next)
+
+suspend fun <A> AmbExc.choose(list: List<A>): A {
+  if (list.isEmpty()) raise()
+  var i = 0
+  while (i < list.lastIndex) {
+    if (flip()) return list[i]
+    i++
+  }
+  return list.last()
+}
+
+// TODO could we make this return Boolean? maybe would need access to the o.g. prompt I guess, or we can do this in some block
+tailrec suspend fun <A> AmbExc.interleave(first: suspend AmbExc.() -> A, second: suspend AmbExc.() -> A): A {
+  val (res, branch) = split(first) ?: return second()
+  return if (flip()) res
+  else interleave(second) { choose(branch) }
+}
+
+// TODO could we make this tailrec?
+suspend fun <A, B> AmbExc.fairBind(first: suspend AmbExc.() -> A, second: suspend AmbExc.(A) -> B): B {
+  val (res, branch) = split(first) ?: raise()
+  return interleave({ second(res) }) { fairBind({ choose(branch) }, second) }
+}
+
+// TODO I think nullOnFailure is a better replacement (or an Option variant)
+suspend inline fun <A, B> AmbExc.ifte(
+  noinline condition: suspend AmbExc.() -> A,
+  then: (A) -> B,
+  otherwise: () -> B
+): B {
+  val (res, branch) = split(condition) ?: return otherwise()
+  // TODO I think we can take out the `then` here
+  return if (flip()) then(res)
+  else then(choose(branch))
+}
+
+suspend fun <A> AmbExc.nullOnFailure(
+  block: suspend AmbExc.() -> A,
+): A? = split(block)?.let { reflect(it) }
+
+suspend fun <A> AmbExc.noneOnFailure(
+  block: suspend AmbExc.() -> A,
+): Option<A> = split(block)?.let { Some(reflect(it)) } ?: None
+
+suspend fun <A> Exc.once(block: suspend AmbExc.() -> A): A {
+  val (res, _) = split(block) ?: raise()
+  return res
+}
+
+suspend fun <A> AmbExc.gnot(block: suspend AmbExc.() -> A) = ifte({ once(block) }, { raise() }) { }
+suspend fun <A> AmbExc.gnot2(block: suspend AmbExc.() -> A) {
+  noneOnFailure { once(block) }.onSome { raise() }
+}
+
+suspend fun <A> Exc.gnot3(block: suspend AmbExc.() -> A) {
+  if (succeeds(block)) raise()
+}
+
+suspend fun <A> succeeds(block: suspend AmbExc.() -> A) = split(block) != null
+
+suspend fun <A> bagOfN(count: Int = -1, block: suspend AmbExc.() -> A): List<A> = bagOfNRec(count, emptyList(), block)
+
+private tailrec suspend fun <A> bagOfNRec(count: Int, acc: List<A>, block: suspend AmbExc.() -> A): List<A> {
+  if (count < -1 || count == 0) return emptyList()
+  val (res, branch) = split(block) ?: return emptyList()
+  return bagOfNRec(if (count == -1) -1 else count - 1, acc + res) { choose(branch) }
+}
+
+suspend fun <A> bagOfN2(count: Int = -1, block: suspend AmbExc.() -> A): List<A> =
+  bagOfNRec2(count, emptyList(), split(block))
+
+// TODO off by one error I think, at least for execution
+private tailrec suspend fun <A> bagOfNRec2(count: Int, acc: List<A>, branch: Branch<A>?): List<A> {
+  if (count < -1 || count == 0) return emptyList()
+  val (res, branch) = branch ?: return emptyList()
+  return bagOfNRec2(if (count == -1) -1 else count - 1, acc + res, branch())
+}
+
+interface Logic : AmbExc {
+  suspend fun <A> split(block: suspend Logic.() -> A): Pair<A, suspend Logic.() -> A>?
+
+  companion object {
+    sealed interface Tree<out A>
+    data object HZero : Tree<Nothing>
+    data class HOne<out A>(val value: A) : Tree<A>
+    data class HChoice<out A>(val value: A, val next: suspend () -> Tree<A>) : Tree<A>
+
+    class LogicImpl<A>(p: HandlerPrompt<Tree<A>>) : Logic, Handler<Tree<A>> by p {
+      override suspend fun raise(msg: String): Nothing = discardWithFast(Result.success(HZero))
+      override suspend fun flip(): Boolean = use { resume ->
+        composeTrees(resume(true)) { resume(false) }
+      }
+
+      override suspend fun <A> split(block: suspend Logic.() -> A): Pair<A, suspend Logic.() -> A>? =
+        reflectSR(reifyLogic(block))
+    }
+
+    private fun <A> reflectSR(tree: Tree<A>): Pair<A, suspend Logic.() -> A>? = when (tree) {
+      HZero -> null
+      is HOne -> Pair(tree.value) { raise() }
+      is HChoice -> {
+        val next = tree.next
+        Pair(tree.value) { reflect(reflectSR(next())) }
+      }
+    }
+
+    private suspend fun <A> Logic.reflect(pair: Pair<A, suspend Logic.() -> A>?): A {
+      val (value, next) = pair ?: raise()
+      return if (flip()) value else next()
+    }
+
+    private suspend fun <A> composeTrees(value: Tree<A>, next: suspend () -> Tree<A>): Tree<A> = when (value) {
+      is HZero -> next()
+      is HOne -> HChoice(value.value, next)
+      is HChoice -> {
+        val nextPrime = value.next
+        HChoice(value.value) { composeTrees(nextPrime(), next) }
+      }
+    }
+
+    private suspend fun <A> reifyLogic(block: suspend Logic.() -> A): Tree<A> = handle {
+      HOne(block(LogicImpl(this)))
+    }
+
+    // TODO could we make this return Boolean? maybe would need access to the o.g. prompt I guess, or we can do this in some block
+    tailrec suspend fun <A> Logic.interleave(first: suspend Logic.() -> A, second: suspend Logic.() -> A): A {
+      val (res, branch) = split(first) ?: return second()
+      return if (flip()) res
+      else interleave(second, branch)
+    }
+
+    // TODO could we make this tailrec?
+    suspend fun <A, B> Logic.fairBind(first: suspend Logic.() -> A, second: suspend Logic.(A) -> B): B {
+      val (res, branch) = split(first) ?: raise()
+      return interleave({ second(res) }) { fairBind(branch, second) }
+    }
+
+    // TODO I think nullOnFailure is a better replacement (or an Option variant)
+    suspend inline fun <A, B> Logic.ifte(
+      noinline condition: suspend Logic.() -> A,
+      then: (A) -> B,
+      otherwise: () -> B
+    ): B {
+      val (res, branch) = split(condition) ?: return otherwise()
+      // TODO I think we can take out the `then` here
+      return if (flip()) then(res)
+      else then(branch())
+    }
+
+    suspend fun <A> Logic.nullOnFailure(
+      block: suspend Logic.() -> A,
+    ): A? = split(block)?.let { reflect(it) }
+
+    suspend fun <A> Logic.noneOnFailure(
+      block: suspend Logic.() -> A,
+    ): Option<A> = split(block)?.let { Some(reflect(it)) } ?: None
+
+    suspend fun <A> Logic.once(block: suspend Logic.() -> A): A {
+      val (res, _) = split(block) ?: raise()
+      return res
+    }
+
+    suspend fun <A> Logic.gnot(block: suspend Logic.() -> A) = ifte({ once(block) }, { raise() }) { }
+    suspend fun <A> Logic.gnot2(block: suspend Logic.() -> A) {
+      noneOnFailure { once(block) }.onSome { raise() }
+    }
+
+    suspend fun <A> Logic.gnot3(block: suspend Logic.() -> A) {
+      if (succeeds(block)) raise()
+    }
+
+    suspend fun <A> Logic.succeeds(block: suspend Logic.() -> A) = split(block) != null
+
+    suspend fun <A> Logic.bagOfN(count: Int = -1, block: suspend Logic.() -> A): List<A> = bagOfNRec(count, emptyList(), block)
+
+    private tailrec suspend fun <A> Logic.bagOfNRec(count: Int, acc: List<A>, block: suspend Logic.() -> A): List<A> {
+      if (count < -1 || count == 0) return emptyList()
+      val (res, branch) = split(block) ?: return emptyList()
+      return bagOfNRec(if (count == -1) -1 else count - 1, acc + res, branch)
+    }
+  }
+}

--- a/library/src/commonTest/kotlin/effekt/ProbabilisticTest.kt
+++ b/library/src/commonTest/kotlin/effekt/ProbabilisticTest.kt
@@ -43,22 +43,27 @@ class ProbabilisticTest {
   }
 }
 
-class ProbHandler<R>(prompt: HandlerPrompt<List<Weighted<R>>>) : Prob, Handler<List<Weighted<R>>> by prompt,
-  StatefulHandler<List<Weighted<R>>, Double> {
+class ProbHandler<R>(prompt: StatefulPrompt<List<Weighted<R>>, Data>) : Prob,
+  StatefulHandler<List<Weighted<R>>, ProbHandler.Data> by prompt {
+  data class Data(var p: Double = 1.0) : Stateful<Data> {
+    override fun fork() = copy()
+  }
+
   override suspend fun flip(): Boolean = use { k ->
-    k(false) + k(true)
+    val previous = get().p
+    k(false).also { get().p = previous } + k(true)
   }
 
   override suspend fun fail(): Nothing = discard { emptyList() }
 
-  override suspend fun factor(p: Double) = set(p * get())
+  override suspend fun factor(p: Double) {
+    get().p = p * get().p
+  }
 }
 
 suspend fun <R> probabilistic(body: suspend ProbHandler<R>.() -> R): List<Weighted<R>> =
-  with(ProbHandler<R>(HandlerPrompt())) {
-    handleStateful(1.0) {
-      listOf(Weighted(body(), get()))
-    }
+  handleStateful(ProbHandler.Data()) {
+    listOf(Weighted(body(ProbHandler(this)), get().p))
   }
 
 data class Weighted<T>(val value: T, val weight: Double)

--- a/library/src/commonTest/kotlin/effekt/SkynetTest.kt
+++ b/library/src/commonTest/kotlin/effekt/SkynetTest.kt
@@ -10,8 +10,8 @@ import kotlin.time.Duration.Companion.minutes
 //    https://github.com/atemerev/skynet
 class SkynetTest {
   // not using effects at all
-  // @Test TODO times out on JS
-  fun skynetNoEffects() = runTestCC {
+  @Test
+  fun skynetNoEffects() = runTestCC(UnconfinedTestDispatcher(), timeout = 10.minutes) {
     suspend fun skynet(num: Int, size: Int, div: Int): Long {
       if (size <= 1) return num.toLong()
       val children = Array(div) {
@@ -78,8 +78,8 @@ class SkynetTest {
   }
 
   // every fiber suspends once before returning the result.
-  // @Test TODO times out on JS
-  fun skynetSuspend() = runTestCC {
+  @Test
+  fun skynetSuspend() = runTestCC(UnconfinedTestDispatcher(), timeout = 10.minutes) {
     suspend fun Suspendable.skynet(num: Int, size: Int, div: Int): Long {
       if (size <= 1) return num.toLong().also { suspend() }
       val children = Array(div) {

--- a/library/src/commonTest/kotlin/effekt/SkynetTest.kt
+++ b/library/src/commonTest/kotlin/effekt/SkynetTest.kt
@@ -3,6 +3,7 @@ package effekt
 import io.kotest.matchers.shouldBe
 import runTestCC
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.minutes
 
 // skynet benchmark:
 //    https://github.com/atemerev/skynet
@@ -50,8 +51,8 @@ class SkynetTest {
   //
   // we also perform "busy waiting" which is pretty slow since it captures the
   // continuation on every wait cycle ...
-  // @Test TODO throws OutOfMemoryError
-  fun skynetScheduler() = runTestCC {
+  @Test
+  fun skynetScheduler() = runTestCC(timeout = 10.minutes) {
     data class SkynetData(var sum: Long, var returned: Int)
 
     suspend fun Scheduler2.skynet(num: Int, size: Int, div: Int): Long {
@@ -72,7 +73,7 @@ class SkynetTest {
       return data.sum
     }
 
-    scheduler2 { skynet(0, 1_000_000, 10) } shouldBe 499_999_500_000L
+    scheduler2 { skynet(0, 1_000_000, 10) shouldBe 499_999_500_000L }
   }
 
   // every fiber suspends once before returning the result.

--- a/library/src/commonTest/kotlin/effekt/SkynetTest.kt
+++ b/library/src/commonTest/kotlin/effekt/SkynetTest.kt
@@ -1,6 +1,7 @@
 package effekt
 
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import runTestCC
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.minutes
@@ -52,7 +53,7 @@ class SkynetTest {
   // we also perform "busy waiting" which is pretty slow since it captures the
   // continuation on every wait cycle ...
   @Test
-  fun skynetScheduler() = runTestCC(timeout = 10.minutes) {
+  fun skynetScheduler() = runTestCC(UnconfinedTestDispatcher(), timeout = 10.minutes) {
     data class SkynetData(var sum: Long, var returned: Int)
 
     suspend fun Scheduler2.skynet(num: Int, size: Int, div: Int): Long {

--- a/library/src/commonTest/kotlin/effekt/StateTest.kt
+++ b/library/src/commonTest/kotlin/effekt/StateTest.kt
@@ -2,7 +2,6 @@ package effekt
 
 import io.kotest.matchers.shouldBe
 import runTestCC
-import kotlin.test.Ignore
 import kotlin.test.Test
 
 class StateTest {
@@ -76,7 +75,6 @@ class StateTest {
   }
 
   @Test
-  @Ignore
   fun silentCountDown() = runTestCC {
     suspend fun State<Int>.countDown() {
       while (get() > 0) {

--- a/library/src/commonTest/kotlin/effekt/StateTest.kt
+++ b/library/src/commonTest/kotlin/effekt/StateTest.kt
@@ -2,6 +2,7 @@ package effekt
 
 import io.kotest.matchers.shouldBe
 import runTestCC
+import kotlin.test.Ignore
 import kotlin.test.Test
 
 class StateTest {
@@ -75,6 +76,7 @@ class StateTest {
   }
 
   @Test
+  @Ignore
   fun silentCountDown() = runTestCC {
     suspend fun State<Int>.countDown() {
       while (get() > 0) {

--- a/library/src/commonTest/kotlin/effekt/StateTest.kt
+++ b/library/src/commonTest/kotlin/effekt/StateTest.kt
@@ -186,13 +186,13 @@ suspend fun <R, S> specialState(init: S, block: suspend State<S>.() -> R): R =
 fun interface StateFun<R, S> : State<S>, Handler<suspend (S) -> R> {
   override suspend fun get(): S = use { k ->
     { s ->
-      k(s, isFinal = true)(s)
+      k(s, shouldClear = true)(s)
     }
   }
 
   override suspend fun put(value: S) = use { k ->
     {
-      k(Unit, isFinal = true)(value)
+      k(Unit, shouldClear = true)(value)
     }
   }
 }

--- a/library/src/commonTest/kotlin/effekt/StateTest.kt
+++ b/library/src/commonTest/kotlin/effekt/StateTest.kt
@@ -185,13 +185,13 @@ suspend fun <R, S> specialState(init: S, block: suspend State<S>.() -> R): R =
   }
 
 fun interface StateFun<R, S> : State<S>, Handler<suspend (S) -> R> {
-  override suspend fun get(): S = use { k ->
+  override suspend fun get(): S = useOnce { k ->
     { s ->
       k(s, shouldClear = true)(s)
     }
   }
 
-  override suspend fun put(value: S) = use { k ->
+  override suspend fun put(value: S) = useOnce { k ->
     {
       k(Unit, shouldClear = true)(value)
     }

--- a/library/src/commonTest/kotlin/effekt/StateTest.kt
+++ b/library/src/commonTest/kotlin/effekt/StateTest.kt
@@ -1,6 +1,7 @@
 package effekt
 
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import runTestCC
 import kotlin.test.Test
 
@@ -75,7 +76,7 @@ class StateTest {
   }
 
   @Test
-  fun silentCountDown() = runTestCC {
+  fun silentCountDown() = runTestCC(UnconfinedTestDispatcher()) {
     suspend fun State<Int>.countDown() {
       while (get() > 0) {
         put(get() - 1)

--- a/library/src/commonTest/kotlin/effekt/UseCasesTest.kt
+++ b/library/src/commonTest/kotlin/effekt/UseCasesTest.kt
@@ -4,7 +4,7 @@ import arrow.core.Option
 import arrow.core.Some
 import arrow.core.recover
 import io.kotest.matchers.shouldBe
-import kotlinx.coroutines.test.runTest
+import runTestCC
 import kotlin.test.Test
 
 class UseCasesTest {
@@ -21,7 +21,7 @@ class UseCasesTest {
   }
 
   @Test
-  fun example() = runTest {
+  fun example() = runTestCC {
     "123".parseAll(Parser2::number) shouldBe listOf(123, 12, 1)
     "123".parseBacktrack { number() } shouldBe Some(123)
   }

--- a/library/src/commonTest/kotlin/effekt/UseCasesTest.kt
+++ b/library/src/commonTest/kotlin/effekt/UseCasesTest.kt
@@ -45,20 +45,20 @@ suspend fun Parser2.number(): Int {
   return res
 }
 
-class StringReader<R>(val input: String, val exc: Exc, prompt: HandlerPrompt<R>) : Receive<Char>,
-  StatefulHandler<R, Int>, Handler<R> by prompt {
+class StringReader<R>(val input: String, val exc: Exc, prompt: StatefulPrompt<R, Data>) : Receive<Char>,
+  StatefulHandler<R, StringReader.Data> by prompt {
+  data class Data(var pos: Int = 0) : Stateful<Data> {
+    override fun fork() = copy()
+  }
+
   override suspend fun receive(): Char {
-    val curPos = get()
-    if (curPos >= input.length) exc.raise("Unexpected EOS")
-    set(curPos + 1)
-    return input[curPos]
+    if (get().pos >= input.length) exc.raise("Unexpected EOS")
+    return input[get().pos++]
   }
 }
 
-suspend fun <R> Exc.stringReader(input: String, block: suspend StringReader<R>.() -> R): R =
-  with(StringReader(input, this, HandlerPrompt<R>())) {
-    handleStateful(0) { block() }
-  }
+suspend fun <R> Exc.stringReader(input: String, block: suspend Receive<Char>.() -> R): R =
+  handleStateful(StringReader.Data()) { block(StringReader(input, this@stringReader, this)) }
 
 interface AmbExc : Amb, Exc
 

--- a/library/src/commonTest/kotlin/effekt/casestudies/NaturalisticDsl.kt
+++ b/library/src/commonTest/kotlin/effekt/casestudies/NaturalisticDsl.kt
@@ -1,7 +1,8 @@
 package effekt.casestudies
 
+import effekt.get
 import effekt.handleStateful
-import effekt.useStateful
+import effekt.use
 import io.kotest.matchers.shouldBe
 import runTestCC
 import kotlin.reflect.KProperty
@@ -71,11 +72,14 @@ suspend fun Quantification.every(who: Predicate) = quantify(who)
 suspend fun s2() = scoped { John said { every(Woman) loves me() } }
 
 //TODO: weird compiler bug. Removing suspend here still compiles s2, but ends up with null continuation
-suspend fun scoped(s: suspend Quantification.() -> Sentence): Sentence = handleStateful(0) {
-  s { who ->
-    useStateful { resume, tmp ->
-      val x = Person("x$tmp")
-      ForAll(x, Implies(Is(x, who), resume(x, tmp + 1)))
+suspend fun scoped(s: suspend Quantification.() -> Sentence): Sentence {
+  data class Data(var i: Int)
+  return handleStateful(Data(0), Data::copy) {
+    s { who ->
+      use { resume ->
+        val x = Person("x${get().i++}")
+        ForAll(x, Implies(Is(x, who), resume(x)))
+      }
     }
   }
 }

--- a/library/src/jvmMain/kotlin/NoTrace.kt
+++ b/library/src/jvmMain/kotlin/NoTrace.kt
@@ -1,13 +1,12 @@
 import kotlinx.coroutines.CancellationException
-import kotlin.coroutines.CoroutineContext
 
 /*
  * Inspired by KotlinX Coroutines:
  * https://github.com/Kotlin/kotlinx.coroutines/blob/3788889ddfd2bcfedbff1bbca10ee56039e024a2/kotlinx-coroutines-core/jvm/src/Exceptions.kt#L29
  */
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
-internal actual abstract class SeekingCoroutineContextException : CancellationException("Should never get swallowed") {
-  actual abstract fun use(context: CoroutineContext)
+internal actual abstract class SeekingStackException : CancellationException("Should never get swallowed") {
+  actual abstract fun use(stack: SplitSeq<*, *>)
   override fun fillInStackTrace(): Throwable {
     // Prevent Android <= 6.0 bug.
     stackTrace = emptyArray()

--- a/library/src/jvmMain/kotlin/NoTrace.kt
+++ b/library/src/jvmMain/kotlin/NoTrace.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.CancellationException
  */
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 internal actual abstract class SeekingStackException : CancellationException("Should never get swallowed") {
-  actual abstract fun use(stack: SplitSeq<*, *>)
+  actual abstract fun use(stack: SplitSeq<*, *, *>)
   override fun fillInStackTrace(): Throwable {
     // Prevent Android <= 6.0 bug.
     stackTrace = emptyArray()

--- a/library/src/jvmMain/kotlin/compilerCloning.kt
+++ b/library/src/jvmMain/kotlin/compilerCloning.kt
@@ -1,4 +1,5 @@
 import kotlin.coroutines.Continuation
+import java.lang.reflect.Modifier
 
 private val UNSAFE = Class.forName("sun.misc.Unsafe").getDeclaredField("theUnsafe").apply { isAccessible = true }
   .get(null) as sun.misc.Unsafe
@@ -28,6 +29,7 @@ private tailrec fun <T> copyDeclaredFields(
   }
   for (i in fields.indices) {
     val field = fields[i]
+    if (Modifier.isStatic(field.modifiers)) continue
     when (field.type) {
       Int::class.java -> field.setInt(copy, field.getInt(obj))
       else -> {

--- a/library/src/jvmMain/kotlin/compilerCloning.kt
+++ b/library/src/jvmMain/kotlin/compilerCloning.kt
@@ -30,7 +30,12 @@ private tailrec fun <T> copyDeclaredFields(
     val field = fields[i]
     when (field.type) {
       Int::class.java -> field.setInt(copy, field.getInt(obj))
-      else -> field.set(copy, field.get(obj))
+      else -> {
+        val v = field.get(obj)
+        // Sometimes generated continuations contain references to themselves
+        // hence we need to change that immediate reference (or else we run into memory leaks)
+        field.set(copy, if (v === obj) copy else v)
+      }
     }
   }
   val superclass = clazz.superclass

--- a/library/src/jvmMain/kotlin/dsl.kt
+++ b/library/src/jvmMain/kotlin/dsl.kt
@@ -1,3 +1,5 @@
+@file:Suppress("CONTEXT_RECEIVERS_DEPRECATED")
+
 import arrow.core.raise.Raise
 import arrow.core.raise.SingletonRaise
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/library/src/jvmMain/kotlin/dsl.kt
+++ b/library/src/jvmMain/kotlin/dsl.kt
@@ -28,7 +28,7 @@ public suspend fun <R> runChoice(
 }
 
 public suspend fun <R> Choose.pushList(body: suspend () -> R): List<R> =
-  runForkingReader(mutableListOf(), MutableList<R>::toMutableList) {
+  runReader(mutableListOf(), MutableList<R>::toMutableList) {
     pushChoice(body) {
       ask().add(it)
     }
@@ -36,7 +36,7 @@ public suspend fun <R> Choose.pushList(body: suspend () -> R): List<R> =
   }
 
 public suspend fun <R> runList(body: suspend context(SingletonRaise<Unit>, Choose) () -> R): List<R> =
-  runForkingReader(mutableListOf(), MutableList<R>::toMutableList) {
+  runReader(mutableListOf(), MutableList<R>::toMutableList) {
     runChoice(body) {
       ask().add(it)
     }

--- a/library/src/jvmTest/kotlin/FlowTest.kt
+++ b/library/src/jvmTest/kotlin/FlowTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.flattenConcat
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.milliseconds
@@ -153,7 +154,7 @@ class FlowTest {
   }
 
   @Test
-  fun forLoops() = runTest {
+  fun forLoops() = runTest(UnconfinedTestDispatcher()) {
     val result = flowReset {
       for (i in 1..10) {
         flowOfWithDelay(i, i).bind()

--- a/library/src/jvmTest/kotlin/effekt/casestudies/Anf.kt
+++ b/library/src/jvmTest/kotlin/effekt/casestudies/Anf.kt
@@ -1,6 +1,7 @@
 package effekt.casestudies
 
 import arrow.core.Either
+import effekt.get
 import effekt.handle
 import effekt.handleStateful
 import effekt.use
@@ -63,11 +64,12 @@ fun interface Fresh {
   suspend fun fresh(): String
 }
 
-suspend fun <R> freshVars(block: suspend context(Fresh) () -> R): R = handleStateful(0) {
-  block {
-    val i = get() + 1
-    set(i)
-    "x$i"
+suspend fun <R> freshVars(block: suspend context(Fresh) () -> R): R {
+  data class Data(var i: Int)
+  return handleStateful(Data(0), Data::copy) {
+    block {
+      "x${++(get().i)}"
+    }
   }
 }
 

--- a/library/src/jvmTest/kotlin/effekt/casestudies/Anf.kt
+++ b/library/src/jvmTest/kotlin/effekt/casestudies/Anf.kt
@@ -1,3 +1,5 @@
+@file:Suppress("CONTEXT_RECEIVERS_DEPRECATED")
+
 package effekt.casestudies
 
 import arrow.core.Either

--- a/library/src/jvmTest/kotlin/effekt/casestudies/PrettyPrinter.kt
+++ b/library/src/jvmTest/kotlin/effekt/casestudies/PrettyPrinter.kt
@@ -1,3 +1,5 @@
+@file:Suppress("CONTEXT_RECEIVERS_DEPRECATED")
+
 package effekt.casestudies
 
 import Raise

--- a/library/src/jvmTest/kotlin/effekt/casestudies/PrettyPrinter.kt
+++ b/library/src/jvmTest/kotlin/effekt/casestudies/PrettyPrinter.kt
@@ -9,10 +9,10 @@ import arrow.core.getOrElse
 import arrow.core.raise.SingletonRaise
 import arrow.core.recover
 import arrow.core.some
+import effekt.get
 import effekt.handle
 import effekt.handleStateful
 import effekt.use
-import effekt.useStateful
 import given
 import io.kotest.matchers.shouldBe
 import runTestCC
@@ -303,34 +303,42 @@ suspend fun <R> searchLayout(p: suspend context(SingletonRaise<Unit>, LayoutChoi
   }.some()
 }
 
-suspend fun writer(p: suspend context(Emit) () -> Unit): String = handleStateful("") {
-  p { text ->
-    set(get() + text)
+suspend fun writer(p: suspend context(Emit) () -> Unit): String {
+  data class Data(var content: String)
+  return handleStateful(Data(""), Data::copy) {
+    p { text ->
+      get().content += text
+    }
+    get().content
   }
-  get()
 }
 
 context(Emit, LayoutChoice, SingletonRaise<Unit>)
 suspend fun printer(
   width: Int, defaultIndent: Int, block: suspend context(Indent, DefaultIndent, Flow, Emit) () -> Unit
-) = handleStateful(0) {
-  val outerEmit = given<Emit>()
-  block(Indent { 0 }, DefaultIndent { defaultIndent }, Flow(::choice), object : Emit {
-    override suspend fun emitText(text: String) = useStateful { k, p ->
-      val pos = p + text.length
-      if (pos > width) {
-        raise()
-      } else {
-        outerEmit.emitText(text)
-        k(Unit, pos)
-      }
-    }
+) {
+  data class PrinterData(var pos: Int)
 
-    override suspend fun emitNewline() = useStateful { k, _ ->
-      outerEmit.emitNewline()
-      k(Unit, 0)
-    }
-  })
+  val outerEmit = given<Emit>()
+  handleStateful(PrinterData(0), PrinterData::copy) {
+    block(Indent { 0 }, DefaultIndent { defaultIndent }, Flow(::choice), object : Emit {
+      override suspend fun emitText(text: String) = use { k ->
+        get().pos += text.length
+        if (get().pos > width) {
+          raise()
+        } else {
+          outerEmit.emitText(text)
+          k(Unit)
+        }
+      }
+
+      override suspend fun emitNewline() = use { k ->
+        outerEmit.emitNewline()
+        get().pos = 0
+        k(Unit)
+      }
+    })
+  }
 }
 
 suspend fun pretty(

--- a/library/src/nonJvmMain/kotlin/NoTrace.kt
+++ b/library/src/nonJvmMain/kotlin/NoTrace.kt
@@ -1,7 +1,6 @@
 import kotlinx.coroutines.CancellationException
-import kotlin.coroutines.CoroutineContext
 
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
-internal actual abstract class SeekingCoroutineContextException: CancellationException("Should never get swallowed") {
-  actual abstract fun use(context: CoroutineContext)
+internal actual abstract class SeekingStackException: CancellationException("Should never get swallowed") {
+  actual abstract fun use(stack: SplitSeq<*, *>)
 }

--- a/library/src/nonJvmMain/kotlin/NoTrace.kt
+++ b/library/src/nonJvmMain/kotlin/NoTrace.kt
@@ -2,5 +2,5 @@ import kotlinx.coroutines.CancellationException
 
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 internal actual abstract class SeekingStackException: CancellationException("Should never get swallowed") {
-  actual abstract fun use(stack: SplitSeq<*, *>)
+  actual abstract fun use(stack: SplitSeq<*, *, *>)
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,5 +15,5 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "comprehension"
+rootProject.name = "KonTinuity"
 include(":library")


### PR DESCRIPTION
Every item of such a sequence is either a mark (Reader/Prompt) or real stack frames (which are now only copied when absolutely necessary).
Technically, there's a one-shot core that can be extracted here that uses no reflection, but I'll leave that to the future. 
This is based on [java-effekt](https://github.com/b-studios/java-effekt/blob/master/core/src/main/scala/effekt/runtime/SplitSeq.scala)'s implementation, but with added types, and explicit tail-rec-ness. I also added kotlin-specific optimizations here to "trampoline" resumptions into frames. That code should ideally be extracted into a smaller component.
Also, this implementation takes O(1) time for `pushPrompt`, O(k) time for `takeSubCont`, and O(k) time for `pushSubCont`, where k is the amount of marks from here to the relevant Prompt (so it's the amount of marks separating us from the Prompt in `takeSubCont`, and the amount of marks in the stored SubCont in `pushSubCont`). I doubt that `takeSubCont` can be made faster (unless we use a hashmap or something), but `pushSubCont` can definitely be made constant-time, although that'll make the code more complex (the likely way to do so is using the "Reflection without Remorse" technique of using a sequence that'll have amortized constant-time access to the "current" continuation frame, but IIRC this has horrible constants involved).
This also implements delayed copying for Reader's values.
This doesn't currently support a dynamic-wind style operation, also it hasn't needed to exist just yet. 